### PR TITLE
Forest 59 gpm mystery

### DIFF
--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/main.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/main.py
@@ -130,7 +130,7 @@ def main(bokeh_id):
                                            )
 
     if init_fcast_time is None:
-        layout1 = forest.utils.load_error_page()
+        layout1 = forest.util.load_error_page()
         bokeh.plotting.curdoc().add_root(layout1)
         return
 

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -272,9 +272,33 @@ class ModelGpmControl(object):
     def imerg_labels(self):
         '''Parse datasets dictionary for IMERG radio button group labels
 
+        At present, datasets are a series of nested dictionaries of the form
+
+        {
+            '20180101': {
+                'gpm_imerg_early': {
+                    'data': ...
+                    'data_type_name': 'GPM IMERG Early',
+                    'gpm_type': 'early'
+                },
+                ...
+            },
+            ...
+        }
+
+        .. note: The above specification is likely to change as the app evolves
+
         :returns: list of strings representing available IMERG datasets
         '''
-        return [ds_name for ds_name in self.datasets.keys() if 'imerg' in ds_name]
+        labels = []
+        for dataset in self.datasets.values():
+            for key, dictionary in dataset.items():
+                if "imerg" not in key:
+                    continue
+                if "data_type_name" not in dictionary:
+                    continue
+                labels.append(dictionary["data_type_name"])
+        return labels
 
     def on_accum_change(self, plot_index, attr1, old_val, new_val):
         

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -300,15 +300,15 @@ class ModelGpmControl(object):
     @property
     def imerg_tuples(self):
         '''Helper method to keep IMERG keys and labels consistent'''
-        pairs = set()
+        pairs = {}
         for dataset in self.datasets.values():
             for key, dictionary in dataset.items():
                 if "imerg" not in key:
                     continue
                 if "data_type_name" not in dictionary:
                     continue
-                pairs.add((key, dictionary["data_type_name"]))
-        return sorted(pairs)
+                pairs[key] = dictionary["data_type_name"]
+        return sorted(pairs.items())
 
     def on_accum_change(self, plot_index, attr1, old_val, new_val):
         

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -270,7 +270,11 @@ class ModelGpmControl(object):
         print('selected new config {0}'.format(imerg_list[new_val]))
         new_config = imerg_list[new_val]
         self.plot_list[plot_index].set_config(new_config)
-        
+
+    def imerg_labels(self):
+        '''Parse datasets dictionary for IMERG radio button group labels'''
+        return []
+
     def on_accum_change(self, plot_index, attr1, old_val, new_val):
         
         '''Event handler for a change in the selected model configuration output.

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -300,6 +300,8 @@ class ModelGpmControl(object):
     @property
     def imerg_tuples(self):
         '''Helper method to keep IMERG keys and labels consistent'''
+        if hasattr(self, "_imerg_tuples"):
+            return self._imerg_tuples
         pairs = {}
         for dataset in self.datasets.values():
             for key, dictionary in dataset.items():
@@ -308,7 +310,8 @@ class ModelGpmControl(object):
                 if "data_type_name" not in dictionary:
                     continue
                 pairs[key] = dictionary["data_type_name"]
-        return sorted(pairs.items())
+        self._imerg_tuples = sorted(pairs.items())
+        return self._imerg_tuples
 
     def on_accum_change(self, plot_index, attr1, old_val, new_val):
         

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -265,15 +265,14 @@ class ModelGpmControl(object):
         if not self.process_events:
             return
 
-        imerg_list = [ds_name for ds_name in self.datasets.keys()
-                      if 'imerg' in ds_name]
+        imerg_list = [ds_name for ds_name in self.datasets.keys() if 'imerg' in ds_name]
         print('selected new config {0}'.format(imerg_list[new_val]))
         new_config = imerg_list[new_val]
         self.plot_list[plot_index].set_config(new_config)
 
     def imerg_labels(self):
         '''Parse datasets dictionary for IMERG radio button group labels'''
-        return []
+        return [ds_name for ds_name in self.datasets.keys() if 'imerg' in ds_name]
 
     def on_accum_change(self, plot_index, attr1, old_val, new_val):
         

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -126,6 +126,7 @@ class ModelGpmControl(object):
                                 functools.partial(self.on_config_change, 0))
 
         # Create GPM IMERG selection radio button group widget
+        # BUG: list comprehension returns empty list due to dataset dictionary change
         imerg_labels = [ds_name for ds_name in self.datasets.keys() if 'imerg' in ds_name]
         self.imerg_rbg = \
             bokeh.models.widgets.RadioButtonGroup(labels=imerg_labels,

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -290,15 +290,15 @@ class ModelGpmControl(object):
 
         :returns: list of strings representing available IMERG datasets
         '''
-        labels = []
+        labels = set()
         for dataset in self.datasets.values():
             for key, dictionary in dataset.items():
                 if "imerg" not in key:
                     continue
                 if "data_type_name" not in dictionary:
                     continue
-                labels.append(dictionary["data_type_name"])
-        return labels
+                labels.add(dictionary["data_type_name"])
+        return sorted(labels)
 
     def on_accum_change(self, plot_index, attr1, old_val, new_val):
         

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -126,7 +126,6 @@ class ModelGpmControl(object):
                                 functools.partial(self.on_config_change, 0))
 
         # Create GPM IMERG selection radio button group widget
-        # BUG: list comprehension returns empty list due to dataset dictionary change
         self.imerg_rbg = \
             bokeh.models.widgets.RadioButtonGroup(labels=self.imerg_labels(),
                                                   button_type='warning',

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -127,9 +127,8 @@ class ModelGpmControl(object):
 
         # Create GPM IMERG selection radio button group widget
         # BUG: list comprehension returns empty list due to dataset dictionary change
-        imerg_labels = [ds_name for ds_name in self.datasets.keys() if 'imerg' in ds_name]
         self.imerg_rbg = \
-            bokeh.models.widgets.RadioButtonGroup(labels=imerg_labels,
+            bokeh.models.widgets.RadioButtonGroup(labels=self.imerg_labels(),
                                                   button_type='warning',
                                                   width=800)
         self.imerg_rbg.on_change('active', 
@@ -265,7 +264,7 @@ class ModelGpmControl(object):
         if not self.process_events:
             return
 
-        imerg_list = [ds_name for ds_name in self.datasets.keys() if 'imerg' in ds_name]
+        imerg_list = self.imerg_labels()
         print('selected new config {0}'.format(imerg_list[new_val]))
         new_config = imerg_list[new_val]
         self.plot_list[plot_index].set_config(new_config)

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -270,7 +270,10 @@ class ModelGpmControl(object):
         self.plot_list[plot_index].set_config(new_config)
 
     def imerg_labels(self):
-        '''Parse datasets dictionary for IMERG radio button group labels'''
+        '''Parse datasets dictionary for IMERG radio button group labels
+
+        :returns: list of strings representing available IMERG datasets
+        '''
         return [ds_name for ds_name in self.datasets.keys() if 'imerg' in ds_name]
 
     def on_accum_change(self, plot_index, attr1, old_val, new_val):

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/model_gpm_control.py
@@ -127,7 +127,7 @@ class ModelGpmControl(object):
 
         # Create GPM IMERG selection radio button group widget
         self.imerg_rbg = \
-            bokeh.models.widgets.RadioButtonGroup(labels=self.imerg_labels(),
+            bokeh.models.widgets.RadioButtonGroup(labels=self.imerg_labels,
                                                   button_type='warning',
                                                   width=800)
         self.imerg_rbg.on_change('active', 
@@ -256,18 +256,24 @@ class ModelGpmControl(object):
         self.plot_list[plot_index].set_config(new_val)
 
     def on_imerg_change(self, plot_index, attr1, old_val, new_val):
-        
         '''Event handler for a change in the selected model configuration output.
-        
         '''
         if not self.process_events:
             return
+        config = self.imerg_configs[new_val]
+        print('selected new config {0}'.format(config))
+        self.plot_list[plot_index].set_config(config)
 
-        imerg_list = self.imerg_labels()
-        print('selected new config {0}'.format(imerg_list[new_val]))
-        new_config = imerg_list[new_val]
-        self.plot_list[plot_index].set_config(new_config)
+    @property
+    def imerg_configs(self):
+        '''IMERG keywords related to radio button group labels
 
+        For example, 'IMERG GPM Late' is identified by 'imerg_gpm_late'
+        in the dataset data structure
+        '''
+        return [config for (config, label) in self.imerg_tuples]
+
+    @property
     def imerg_labels(self):
         '''Parse datasets dictionary for IMERG radio button group labels
 
@@ -289,15 +295,20 @@ class ModelGpmControl(object):
 
         :returns: list of strings representing available IMERG datasets
         '''
-        labels = set()
+        return [label for (config, label) in self.imerg_tuples]
+
+    @property
+    def imerg_tuples(self):
+        '''Helper method to keep IMERG keys and labels consistent'''
+        pairs = set()
         for dataset in self.datasets.values():
             for key, dictionary in dataset.items():
                 if "imerg" not in key:
                     continue
                 if "data_type_name" not in dictionary:
                     continue
-                labels.add(dictionary["data_type_name"])
-        return sorted(labels)
+                pairs.add((key, dictionary["data_type_name"]))
+        return sorted(pairs)
 
     def on_accum_change(self, plot_index, attr1, old_val, new_val):
         

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/run-tests.sh
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/run-tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 -m unittest discover

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_data.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_data.py
@@ -1,0 +1,18 @@
+import unittest
+import forest
+import numpy as np
+
+
+class TestGetAvailableTimes(unittest.TestCase):
+    def test_get_available_times(self):
+        mock_dataset = unittest.mock.Mock()
+        mock_dataset.get_times.return_value = []
+        datasets = {
+            "key": {
+                "data": mock_dataset
+            }
+        }
+        variable = "variable"
+        result = forest.data.get_available_times(datasets, variable)
+        expect = []
+        np.testing.assert_array_equal(expect, result)

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
@@ -4,4 +4,32 @@ import forest
 
 class TestForestPlot(unittest.TestCase):
     def test_can_be_constructed(self):
-        pass
+        """the minimal information needed to construct a ForestPlot"""
+        dataset = {
+            "current_config": {
+                "data_type_name": None
+            }
+        }
+        model_run_time = None
+        po1 = None
+        figname = None
+        plot_var = None
+        conf1 = "current_config"
+        reg1 = None
+        rd1 = None
+        unit_dict = None
+        unit_dict_display = None
+        app_path = None
+        init_time = None
+        forest.plot.ForestPlot(dataset,
+                               model_run_time,
+                               po1,
+                               figname,
+                               plot_var,
+                               conf1,
+                               reg1,
+                               rd1,
+                               unit_dict,
+                               unit_dict_display,
+                               app_path,
+                               init_time)

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
@@ -43,7 +43,7 @@ class TestForestPlot(unittest.TestCase):
                 "data_type_name": None
             },
             "new_config": {
-                "data_type_name": None
+                "data_type_name": "Label"
             }
         }
         model_run_time = None
@@ -75,4 +75,10 @@ class TestForestPlot(unittest.TestCase):
                                                  init_time)
             forest_plot.plot_funcs[plot_var] = mock_plot
             forest_plot.update_bokeh_img_plot_from_fig = unittest.mock.Mock()
+            # System under test
             forest_plot.set_config("new_config")
+
+            # Assertions
+            forest_plot.update_bokeh_img_plot_from_fig.assert_called_once_with()
+            mock_plot.assert_called_once_with()
+            self.assertEqual(forest_plot.plot_description, "Label")

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
@@ -13,10 +13,12 @@ class TestForestPlot(unittest.TestCase):
         model_run_time = None
         po1 = None
         figname = None
-        plot_var = None
+        plot_var = "plot_variable"
         conf1 = "current_config"
-        reg1 = None
-        rd1 = None
+        reg1 = "current_region"
+        rd1 = {
+            "current_region": None
+        }
         unit_dict = None
         unit_dict_display = None
         app_path = None

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
@@ -1,0 +1,7 @@
+import unittest
+import forest
+
+
+class TestForestPlot(unittest.TestCase):
+    def test_can_be_constructed(self):
+        pass

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
@@ -35,3 +35,44 @@ class TestForestPlot(unittest.TestCase):
                                unit_dict_display,
                                app_path,
                                init_time)
+
+    def test_set_config(self):
+        """minimal data needed to call set_config"""
+        dataset = {
+            "current_config": {
+                "data_type_name": None
+            },
+            "new_config": {
+                "data_type_name": None
+            }
+        }
+        model_run_time = None
+        po1 = None
+        figname = None
+        plot_var = "plot_variable"
+        conf1 = "current_config"
+        reg1 = "current_region"
+        rd1 = {
+            "current_region": None
+        }
+        unit_dict = None
+        unit_dict_display = None
+        app_path = None
+        init_time = None
+        mock_plot = unittest.mock.Mock()
+        with unittest.mock.patch("forest.plot.matplotlib") as matplotlib:
+            forest_plot = forest.plot.ForestPlot(dataset,
+                                                 model_run_time,
+                                                 po1,
+                                                 figname,
+                                                 plot_var,
+                                                 conf1,
+                                                 reg1,
+                                                 rd1,
+                                                 unit_dict,
+                                                 unit_dict_display,
+                                                 app_path,
+                                                 init_time)
+            forest_plot.plot_funcs[plot_var] = mock_plot
+            forest_plot.update_bokeh_img_plot_from_fig = unittest.mock.Mock()
+            forest_plot.set_config("new_config")

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_forest_plot.py
@@ -81,4 +81,5 @@ class TestForestPlot(unittest.TestCase):
             # Assertions
             forest_plot.update_bokeh_img_plot_from_fig.assert_called_once_with()
             mock_plot.assert_called_once_with()
+            self.assertEqual(forest_plot.current_config, "new_config")
             self.assertEqual(forest_plot.plot_description, "Label")

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
@@ -1,0 +1,6 @@
+import unittest
+import main
+
+class TestMain(unittest.TestCase):
+    def test_main_can_be_called(self):
+        main.main()

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
@@ -1,6 +1,27 @@
 import unittest
+import unittest.mock
 import main
 
+
 class TestMain(unittest.TestCase):
+    def setUp(self):
+        self.init_fcast_time = "20180101"
+
     def test_main_can_be_called(self):
-        main.main()
+        with unittest.mock.patch("main.bokeh") as bokeh:
+            main.main(bokeh_id="")
+
+    @unittest.mock.patch("main.forest.plot.ForestPlot")
+    @unittest.mock.patch("main.forest.data.get_available_times")
+    @unittest.mock.patch("main.forest.data.get_available_datasets")
+    @unittest.mock.patch("main.model_gpm_control")
+    def test_main_calls_modelgpmcontrol(self,
+                                        model_gpm_control,
+                                        get_available_datasets,
+                                        get_available_times,
+                                        ForestPlot):
+        get_available_datasets.return_value = self.init_fcast_time, {self.init_fcast_time: {}}
+        get_available_times.return_value = [None, None, None, None, None]
+        with unittest.mock.patch("main.bokeh") as bokeh:
+            main.main(bokeh_id="")
+            model_gpm_control.ModelGpmControl.assert_called_once_with()

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
@@ -6,6 +6,7 @@ import main
 class TestMain(unittest.TestCase):
     def setUp(self):
         self.init_fcast_time = "20180101"
+        self.gpm_dataset = "GpmDataset"
 
     def test_main_can_be_called(self):
         with unittest.mock.patch("main.bokeh") as bokeh:
@@ -14,12 +15,15 @@ class TestMain(unittest.TestCase):
     @unittest.mock.patch("main.forest.plot.ForestPlot")
     @unittest.mock.patch("main.forest.data.get_available_times")
     @unittest.mock.patch("main.forest.data.get_available_datasets")
+    @unittest.mock.patch("main.model_gpm_data")
     @unittest.mock.patch("main.model_gpm_control")
     def test_main_calls_modelgpmcontrol(self,
                                         model_gpm_control,
+                                        model_gpm_data,
                                         get_available_datasets,
                                         get_available_times,
                                         ForestPlot):
+        model_gpm_data.GpmDataset.return_value = self.gpm_dataset
         get_available_datasets.return_value = self.init_fcast_time, {self.init_fcast_time: {}}
         get_available_times.return_value = [None, None, None, None, None]
         with unittest.mock.patch("main.bokeh") as bokeh:
@@ -28,12 +32,12 @@ class TestMain(unittest.TestCase):
             expect = {
                self.init_fcast_time: {
                    "gpm_imerg_early": {
-                       "data": None,
+                       "data": self.gpm_dataset,
                        "data_type_name": "GPM IMERG Early",
                        "gpm_type": "early"
                    },
                    "gpm_imerg_late": {
-                       "data": None,
+                       "data": self.gpm_dataset,
                        "data_type_name": "GPM IMERG Late",
                        "gpm_type": "late"
                    },

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_main.py
@@ -24,4 +24,19 @@ class TestMain(unittest.TestCase):
         get_available_times.return_value = [None, None, None, None, None]
         with unittest.mock.patch("main.bokeh") as bokeh:
             main.main(bokeh_id="")
-            model_gpm_control.ModelGpmControl.assert_called_once_with()
+            args, kwargs = model_gpm_control.ModelGpmControl.call_args
+            expect = {
+               self.init_fcast_time: {
+                   "gpm_imerg_early": {
+                       "data": None,
+                       "data_type_name": "GPM IMERG Early",
+                       "gpm_type": "early"
+                   },
+                   "gpm_imerg_late": {
+                       "data": None,
+                       "data_type_name": "GPM IMERG Late",
+                       "gpm_type": "late"
+                   },
+               }
+            }
+            self.assertEqual(args[1], expect)

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -3,18 +3,30 @@ import model_gpm_control
 
 
 class TestModelGpmControl(unittest.TestCase):
+    def setUp(self):
+        self.init_fcast_time = "20180101"
+
     def test_can_be_constructed(self):
         init_var = ""
-        datasets = []
+        mock_gpm_dataset = unittest.mock.Mock()
+        mock_gpm_dataset.get_times.return_value = [
+            self.init_fcast_time
+        ]
+        datasets = {self.init_fcast_time: {
+            "gpm_imerg_early": {
+                "data": mock_gpm_dataset
+            }
+        }}
         init_time_ix = 0
-        init_fcast_time = ""
+        init_fcast_time = self.init_fcast_time
         plot_list = []
         bokeh_img_list = []
-        stats_list = []
-        model_gpm_control.ModelGpmControl(init_var,
-                                          datasets,
-                                          init_time_ix,
-                                          init_fcast_time,
-                                          plot_list,
-                                          bokeh_img_list,
-                                          stats_list)
+        stats_list = [None, None]
+        with unittest.mock.patch("model_gpm_control.bokeh") as bokeh:
+            model_gpm_control.ModelGpmControl(init_var,
+                                              datasets,
+                                              init_time_ix,
+                                              init_fcast_time,
+                                              plot_list,
+                                              bokeh_img_list,
+                                              stats_list)

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -76,6 +76,9 @@ class TestModelGpmControl(unittest.TestCase):
         })
         self.assertEqual(fixture.imerg_labels(), [])
 
+    def test_on_imerg_change(self, bokeh):
+        """simulate what happens when an IMERG button is clicked"""
+
     def make_radio_button_group(self, datasets):
         init_var = ""
         init_time_ix = 0

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -86,17 +86,21 @@ class TestModelGpmControl(unittest.TestCase):
         attr1 = None
         old_val = 0
         new_val = 1
-        controller = self.make_model_gpm_controller(self.datasets)
+        mock_plot = unittest.mock.Mock()
+        plot_list = [None, mock_plot]
+        controller = self.make_model_gpm_controller(self.datasets,
+                                                    plot_list=plot_list)
         controller.on_imerg_change(plot_index,
                                    attr1,
                                    old_val,
                                    new_val)
+        mock_plot.set_config.assert_called_once_with("GPM IMERG Late")
 
-    def make_model_gpm_controller(self, datasets):
+    def make_model_gpm_controller(self, datasets,
+                                  plot_list=()):
         init_var = ""
         init_time_ix = 0
         init_fcast_time = self.init_fcast_time
-        plot_list = []
         bokeh_img_list = []
         stats_list = [None, None]
         return model_gpm_control.ModelGpmControl(init_var,

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -1,0 +1,20 @@
+import unittest
+import model_gpm_control
+
+
+class TestModelGpmControl(unittest.TestCase):
+    def test_can_be_constructed(self):
+        init_var = ""
+        datasets = []
+        init_time_ix = 0
+        init_fcast_time = ""
+        plot_list = []
+        bokeh_img_list = []
+        stats_list = []
+        model_gpm_control.ModelGpmControl(init_var,
+                                          datasets,
+                                          init_time_ix,
+                                          init_fcast_time,
+                                          plot_list,
+                                          bokeh_img_list,
+                                          stats_list)

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -6,26 +6,11 @@ import model_gpm_control
 class TestModelGpmControl(unittest.TestCase):
     def setUp(self):
         self.init_fcast_time = "20180101"
-
-    def test_radio_button_group_constructed_with_imerg_early_late(self, bokeh):
-        self.make_radio_button_group()
-        bokeh.models.widgets.RadioButtonGroup.assert_any_call(
-            labels=[],
-            button_type='warning',
-            width=800
-        )
-
-    def test_imerg_labels(self, bokeh):
-        fixture = self.make_radio_button_group()
-        self.assertEqual(fixture.imerg_labels(), [])
-
-    def make_radio_button_group(self):
-        init_var = ""
         mock_gpm_dataset = unittest.mock.Mock()
         mock_gpm_dataset.get_times.return_value = [
             self.init_fcast_time
         ]
-        datasets = {
+        self.datasets = {
             self.init_fcast_time: {
                 "gpm_imerg_early": {
                     "data": mock_gpm_dataset,
@@ -39,6 +24,35 @@ class TestModelGpmControl(unittest.TestCase):
                 }
             }
         }
+
+    def test_radio_button_group_constructed_with_imerg_early_late(self, bokeh):
+        self.make_radio_button_group(self.datasets)
+        bokeh.models.widgets.RadioButtonGroup.assert_any_call(
+            labels=[],
+            button_type='warning',
+            width=800
+        )
+
+    def test_imerg_labels_given_realistic_dictionary(self, bokeh):
+        fixture = self.make_radio_button_group(self.datasets)
+        self.assertEqual(fixture.imerg_labels(), [])
+
+    def test_imerg_labels_given_minimal_dictionary_returns_empty_list(self, bokeh):
+        class FakeDataset(object):
+            def get_times(self, variable):
+                return [None]
+        fake_dataset = FakeDataset()
+        fixture = self.make_radio_button_group({
+            self.init_fcast_time: {
+                "key": {
+                    "data": fake_dataset
+                }
+            }
+        })
+        self.assertEqual(fixture.imerg_labels(), [])
+
+    def make_radio_button_group(self, datasets):
+        init_var = ""
         init_time_ix = 0
         init_fcast_time = self.init_fcast_time
         plot_list = []

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -12,11 +12,20 @@ class TestModelGpmControl(unittest.TestCase):
         mock_gpm_dataset.get_times.return_value = [
             self.init_fcast_time
         ]
-        datasets = {self.init_fcast_time: {
-            "gpm_imerg_early": {
-                "data": mock_gpm_dataset
+        datasets = {
+            self.init_fcast_time: {
+                "gpm_imerg_early": {
+                    "data": mock_gpm_dataset,
+                    "data_type_name": "GPM IMERG Early",
+                    "gpm_type": "early"
+                },
+                "gpm_imerg_late": {
+                    "data": mock_gpm_dataset,
+                    "data_type_name": "GPM IMERG Late",
+                    "gpm_type": "late"
+                }
             }
-        }}
+        }
         init_time_ix = 0
         init_fcast_time = self.init_fcast_time
         plot_list = []

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -77,7 +77,20 @@ class TestModelGpmControl(unittest.TestCase):
         self.assertEqual(fixture.imerg_labels(), [])
 
     def test_on_imerg_change(self, bokeh):
-        """simulate what happens when an IMERG button is clicked"""
+        """simulate what happens when an IMERG button is clicked
+
+        .. note: the callback used is a curried version of the
+                 method with the first argument set to 1
+        """
+        plot_index = 1
+        attr1 = None
+        old_val = 0
+        new_val = 1
+        controller = self.make_model_gpm_controller(self.datasets)
+        controller.on_imerg_change(plot_index,
+                                   attr1,
+                                   old_val,
+                                   new_val)
 
     def make_model_gpm_controller(self, datasets):
         init_var = ""

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -2,11 +2,24 @@ import unittest
 import model_gpm_control
 
 
+@unittest.mock.patch("model_gpm_control.bokeh")
 class TestModelGpmControl(unittest.TestCase):
     def setUp(self):
         self.init_fcast_time = "20180101"
 
-    def test_radio_button_group_constructed_with_imerg_early_late(self):
+    def test_radio_button_group_constructed_with_imerg_early_late(self, bokeh):
+        self.make_radio_button_group()
+        bokeh.models.widgets.RadioButtonGroup.assert_any_call(
+            labels=[],
+            button_type='warning',
+            width=800
+        )
+
+    def test_imerg_labels(self, bokeh):
+        fixture = self.make_radio_button_group()
+        self.assertEqual(fixture.imerg_labels(), [])
+
+    def make_radio_button_group(self):
         init_var = ""
         mock_gpm_dataset = unittest.mock.Mock()
         mock_gpm_dataset.get_times.return_value = [
@@ -31,16 +44,10 @@ class TestModelGpmControl(unittest.TestCase):
         plot_list = []
         bokeh_img_list = []
         stats_list = [None, None]
-        with unittest.mock.patch("model_gpm_control.bokeh") as bokeh:
-            model_gpm_control.ModelGpmControl(init_var,
-                                              datasets,
-                                              init_time_ix,
-                                              init_fcast_time,
-                                              plot_list,
-                                              bokeh_img_list,
-                                              stats_list)
-            bokeh.models.widgets.RadioButtonGroup.assert_any_call(
-                labels=[],
-                button_type='warning',
-                width=800
-            )
+        return model_gpm_control.ModelGpmControl(init_var,
+                                                 datasets,
+                                                 init_time_ix,
+                                                 init_fcast_time,
+                                                 plot_list,
+                                                 bokeh_img_list,
+                                                 stats_list)

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -6,7 +6,7 @@ class TestModelGpmControl(unittest.TestCase):
     def setUp(self):
         self.init_fcast_time = "20180101"
 
-    def test_can_be_constructed(self):
+    def test_radio_button_group_constructed_with_imerg_early_late(self):
         init_var = ""
         mock_gpm_dataset = unittest.mock.Mock()
         mock_gpm_dataset.get_times.return_value = [
@@ -30,3 +30,8 @@ class TestModelGpmControl(unittest.TestCase):
                                               plot_list,
                                               bokeh_img_list,
                                               stats_list)
+            bokeh.models.widgets.RadioButtonGroup.assert_any_call(
+                labels=[],
+                button_type='warning',
+                width=800
+            )

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -27,7 +27,7 @@ class TestModelGpmControl(unittest.TestCase):
         }
 
     def test_radio_button_group_constructed_with_imerg_early_late(self, bokeh):
-        self.make_radio_button_group(self.datasets)
+        self.make_model_gpm_controller(self.datasets)
         bokeh.models.widgets.RadioButtonGroup.assert_any_call(
             labels=["GPM IMERG Early", "GPM IMERG Late"],
             button_type='warning',
@@ -35,7 +35,7 @@ class TestModelGpmControl(unittest.TestCase):
         )
 
     def test_imerg_labels_given_realistic_dictionary_returns_labels(self, bokeh):
-        fixture = self.make_radio_button_group(self.datasets)
+        fixture = self.make_model_gpm_controller(self.datasets)
         expect = ["GPM IMERG Early", "GPM IMERG Late"]
         self.assertEqual(fixture.imerg_labels(), expect)
 
@@ -45,7 +45,7 @@ class TestModelGpmControl(unittest.TestCase):
                 self.times = times
             def get_times(self, variable):
                 return self.times
-        fixture = self.make_radio_button_group({
+        fixture = self.make_model_gpm_controller({
             "20180101": {
                 "gpm_imerg_early": {
                     "data": FakeDataset(["20180101"]),
@@ -67,7 +67,7 @@ class TestModelGpmControl(unittest.TestCase):
             def get_times(self, variable):
                 return [None]
         fake_dataset = FakeDataset()
-        fixture = self.make_radio_button_group({
+        fixture = self.make_model_gpm_controller({
             self.init_fcast_time: {
                 "key": {
                     "data": fake_dataset
@@ -79,7 +79,7 @@ class TestModelGpmControl(unittest.TestCase):
     def test_on_imerg_change(self, bokeh):
         """simulate what happens when an IMERG button is clicked"""
 
-    def make_radio_button_group(self, datasets):
+    def make_model_gpm_controller(self, datasets):
         init_var = ""
         init_time_ix = 0
         init_fcast_time = self.init_fcast_time

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -37,7 +37,7 @@ class TestModelGpmControl(unittest.TestCase):
     def test_imerg_labels_given_realistic_dictionary_returns_labels(self, bokeh):
         fixture = self.make_model_gpm_controller(self.datasets)
         expect = ["GPM IMERG Early", "GPM IMERG Late"]
-        self.assertEqual(fixture.imerg_labels(), expect)
+        self.assertEqual(fixture.imerg_labels, expect)
 
     def test_imerg_labels_given_duplicate_labels_returns_unique_labels(self, bokeh):
         class FakeDataset(object):
@@ -60,7 +60,7 @@ class TestModelGpmControl(unittest.TestCase):
             }
         })
         expect = ["GPM IMERG Early"]
-        self.assertEqual(fixture.imerg_labels(), expect)
+        self.assertEqual(fixture.imerg_labels, expect)
 
     def test_imerg_labels_given_minimal_dictionary_returns_empty_list(self, bokeh):
         class FakeDataset(object):
@@ -74,7 +74,7 @@ class TestModelGpmControl(unittest.TestCase):
                 }
             }
         })
-        self.assertEqual(fixture.imerg_labels(), [])
+        self.assertEqual(fixture.imerg_labels, [])
 
     def test_on_imerg_change(self, bokeh):
         """simulate what happens when an IMERG button is clicked
@@ -94,7 +94,7 @@ class TestModelGpmControl(unittest.TestCase):
                                    attr1,
                                    old_val,
                                    new_val)
-        mock_plot.set_config.assert_called_once_with("GPM IMERG Late")
+        mock_plot.set_config.assert_called_once_with("gpm_imerg_late")
 
     def make_model_gpm_controller(self, datasets,
                                   plot_list=()):

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -28,14 +28,15 @@ class TestModelGpmControl(unittest.TestCase):
     def test_radio_button_group_constructed_with_imerg_early_late(self, bokeh):
         self.make_radio_button_group(self.datasets)
         bokeh.models.widgets.RadioButtonGroup.assert_any_call(
-            labels=[],
+            labels=["GPM IMERG Early", "GPM IMERG Late"],
             button_type='warning',
             width=800
         )
 
-    def test_imerg_labels_given_realistic_dictionary(self, bokeh):
+    def test_imerg_labels_given_realistic_dictionary_returns_labels(self, bokeh):
         fixture = self.make_radio_button_group(self.datasets)
-        self.assertEqual(fixture.imerg_labels(), [])
+        expect = ["GPM IMERG Early", "GPM IMERG Late"]
+        self.assertEqual(fixture.imerg_labels(), expect)
 
     def test_imerg_labels_given_minimal_dictionary_returns_empty_list(self, bokeh):
         class FakeDataset(object):

--- a/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
+++ b/bokeh_apps/plot_sea_model_and_gpm_mpl/test_model_gpm_control.py
@@ -1,4 +1,5 @@
 import unittest
+import forest
 import model_gpm_control
 
 
@@ -36,6 +37,29 @@ class TestModelGpmControl(unittest.TestCase):
     def test_imerg_labels_given_realistic_dictionary_returns_labels(self, bokeh):
         fixture = self.make_radio_button_group(self.datasets)
         expect = ["GPM IMERG Early", "GPM IMERG Late"]
+        self.assertEqual(fixture.imerg_labels(), expect)
+
+    def test_imerg_labels_given_duplicate_labels_returns_unique_labels(self, bokeh):
+        class FakeDataset(object):
+            def __init__(self, times):
+                self.times = times
+            def get_times(self, variable):
+                return self.times
+        fixture = self.make_radio_button_group({
+            "20180101": {
+                "gpm_imerg_early": {
+                    "data": FakeDataset(["20180101"]),
+                    "data_type_name": "GPM IMERG Early"
+                }
+            },
+            "20180102": {
+                "gpm_imerg_early": {
+                    "data": FakeDataset(["20180102"]),
+                    "data_type_name": "GPM IMERG Early"
+                }
+            }
+        })
+        expect = ["GPM IMERG Early"]
         self.assertEqual(fixture.imerg_labels(), expect)
 
     def test_imerg_labels_given_minimal_dictionary_returns_empty_list(self, bokeh):


### PR DESCRIPTION
This branch addresses the bug reported in #59 

The mystery of the missing GPM IMERG Early/Late button group has been solved by adding unit tests to understand the nested dictionary structure that gets generated in `main.py` passed around between the `ModelGpmControl` instance and `ForestPlot`. The solution was to parse the datasets dictionary correctly in main.py and to send the appropriate keys to ForestPlot

While not a 100% clean fix, it was a nice foray into the code base. I've learned a lot about Bokeh and the organisation of the various Forest apps and library code 