### PR TITLE
Fix auto deploy - hopefully this time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_deploy:
 deploy:
   skip_cleanup: true
   provider: script
-  script: 
-    - helm upgrade forest kube
-    - kubectl delete --all pods --namespace=forest 
+  script: helm upgrade forest kube & kubectl delete --all pods --namespace=forest
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_deploy:
 deploy:
   skip_cleanup: true
   provider: script
-  script: helm upgrade forest kube
+  script: 
+    - helm upgrade forest kube
+    - kubectl delete --all pods --namespace=forest 
   on:
     branch: master

--- a/forest_lib/run_forest_server.sh
+++ b/forest_lib/run_forest_server.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
+conda install bokeh=0.13.0 -y
 export S3_ROOT=$1
-bokeh serve --allow-websocket-origin ${FOREST_URL} --port=$2 $3/*
+bokeh serve --allow-websocket-origin ${FOREST_URL} --port=$2 $3/plot_sea_two_model_comparison

--- a/kube/templates/forest_deployment-dev.yaml
+++ b/kube/templates/forest_deployment-dev.yaml
@@ -9,13 +9,13 @@ spec:
     metadata:
       labels:
         app: {{ .Values.managerdev.name }}
+        deployedAt : "{{ .Release.Time.Seconds }}"
     spec:
+      
       containers:
         - image: informaticslab/singleuser-notebook:0.3.4
           command: ["bash"]
           args: ["-c",". /github_repos/forest/forest_lib/run_forest_server.sh /s3 {{.Values.managerdev.port}} /github_repos/forest/bokeh_apps/"]
-#          command: ["python"]
-#          args: ["-c","import time; time.sleep(5000)"]
 
           name: {{ .Values.managerdev.name }}
           ports:


### PR DESCRIPTION
The auto deploy doesn't happen because the spec doesn't change when the forest code changes. By adding a timestamp to the deployment spec the spec changes on `helm update` so pod should be recreated and so the latest code ('HEAD') pulled down...