### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@ This repository hosts the code to visualise forecast model output and observatio
 
 ## Installation
 
-At present installation is a simple case of cloning this repository. The
-setup.py and conda-spec.txt are intended to make it easier to build the
-package inside a virtual environment.
+The easiest way to install forest is with [conda](https://conda.io/miniconda.html):
 
-Currently there is work taking place to deploy FOREST with conda, but this
-has yet to be finalised.
+    conda install -c conda-forge forest
 
 ## Documentation
 


### PR DESCRIPTION
Update the installation instructions to refer uses to install `forest` with `conda`.

We may want to have a separate INSTALL page, for fuller details, particularly to cover installing from source. This may be helpful if we consider extending `forest` to PyPI.