### PR TITLE
add --use-xheaders flag to bokeh serve command

### DIFF
--- a/server/run-ec2.sh
+++ b/server/run-ec2.sh
@@ -2,6 +2,7 @@
 REPO_DIR=$1
 BUCKET_DIR=$2
 bokeh serve \
+    --use-xheaders \
     --port 8080 \
     --allow-websocket-origin forest.informaticslab.co.uk \
      ${REPO_DIR}/forest \


### PR DESCRIPTION
Added `--use-xheaders` flag to see if IP issues are causing templating problems when EC2 fleet is autoscaled