### PR TITLE
Autoscale

### DIFF
--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -64,4 +64,39 @@
             {% endif %}
         {% endfor %}
     {% endfor %}
+    <script>
+// Re-attach roots if WebSocket request served by different machine
+let reattachRoots = function() {
+    // Find template roots
+    let classNames = ["control-panel", "series-panel"];
+    let parents = classNames.reduce(function(data, className) {
+        data[className] = document.getElementsByClassName(className)[0];
+        return data
+    }, {})
+    if (parents[classNames[0]].children[0].innerHTML !== "") {
+        // First template root populated correctly
+        return
+    }
+
+    // Find orphan roots
+    let roots = document.getElementsByClassName('bk-root')
+    let orphans = [...roots].filter((r) => !('data-root-id' in r.attributes))
+    if (orphans.length === 0) {
+        // No orphans to re-home
+        return
+    }
+
+    // NOTE: Order important since orphaned roots have no data-root-id attr
+    parents['control-panel'].appendChild(orphans[0])
+    parents['series-panel'].appendChild(orphans[1])
+}
+
+oldLog = console.log;
+console.log = function(message) {
+    if (message.localeCompare('Bokeh items were rendered successfully') == 0) {
+        console.log = oldLog;
+        reattachRoots();
+    }
+}
+    </script>
 {% endblock %}

--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -55,16 +55,12 @@
                 <div class="control-panel">
                 {{ embed(root) | indent(10) }}
                 </div>
-            {% endif %}
-            {% if root.name == "height" %}
-                <div class="height-panel">
-                {{ embed(root) | indent(10) }}
-                </div>
-            {% endif %}
-            {% if root.name == "series" %}
+            {% elif root.name == "series" %}
                 <div class="series-panel">
                 {{ embed(root) | indent(10) }}
                 </div>
+            {% else %}
+                {{ embed(root) | indent(10) }}
             {% endif %}
         {% endfor %}
     {% endfor %}

--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -68,5 +68,4 @@
             {% endif %}
         {% endfor %}
     {% endfor %}
-    {{ super() }}
 {% endblock %}


### PR DESCRIPTION

This branch solves the issue of layout problems when scaled beyond a single EC2 instance. Since the load balancer has no knowledge of the underlying bokeh apps it passes requests on to the least loaded instance, sometimes that means the request serving templated HTML is from a different machine to the machine that opens a web socket. In more complicated apps this is a serious issue, but in our case session affinity is not important to us.

A simple JS fix in the end, by taking advantage of our knowledge of how the HTML should look in a correctly rendered page and how it looks when different machines process requests.