### PR TITLE
Enable test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,18 @@
+#
+# coveragerc to control coverage.py
+#
+
+[run]
+branch = True
+include =
+    forest/*
+omit = 
+    setup.py
+    test/*
+
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 kubeconfig
 *.swp
 node_modules
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,5 @@ install:
 
 script:
   - pytest
+
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ## Forecast and Observation Research and Evaluation Survey Tool
 
 [![Build Status](https://travis-ci.com/informatics-lab/forest.svg?branch=master)](https://travis-ci.com/informatics-lab/forest)
+[![Coverage Status](https://coveralls.io/repos/github/informatics-lab/forest/badge.svg?branch=master)](https://coveralls.io/github/informatics-lab/forest?branch=master)
 
 This repository hosts the code to visualise forecast model output and observation data in a web portal, as well as the scripts and configuration files to deploy the server infrastructure.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
+coveralls
 pytest
+pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,8 @@ testpaths = forest
 addopts = 
   -ra
   -v
+  --cov-config .coveragerc
+  --cov=forest
+  --cov-report term-missing
   --doctest-modules
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS 


### PR DESCRIPTION
This PR enables test coverage for `forest` and adds a badge to the `README.md`.

@andrewgryan Akin to `travis-ci`, you will require to turn-on [coveralls](https://coveralls.io/) for the `informatics-lab/forest` repo. Happy to talk you through this.
 