### PR TITLE
Read GHRSST Level 4 NetCDF data files

### DIFF
--- a/forest/geo.py
+++ b/forest/geo.py
@@ -9,6 +9,11 @@ import scipy.ndimage
 
 
 def stretch_image(lons, lats, values):
+    if np.ma.is_masked(values):
+        mask = values.mask
+    else:
+        mask = None
+
     gx, _ = web_mercator(
         lons,
         np.zeros(len(lons), dtype="d"))
@@ -16,6 +21,10 @@ def stretch_image(lons, lats, values):
         np.zeros(len(lats), dtype="d"),
         lats)
     image = stretch_y(gy)(values)
+    if mask is not None:
+        image_mask = stretch_y(gy)(mask)
+        image = np.ma.masked_array(image, mask=image_mask)
+
     x = gx.min()
     y = gy.min()
     dw = gx[-1] - gx[0]

--- a/forest/ghrsstl4.py
+++ b/forest/ghrsstl4.py
@@ -1,0 +1,136 @@
+"""
+Read GHRSST L4 data.
+
+These conventions should conform the GDS 2.0 conventions (based on cf1.7)
+See:
+https://www.ghrsst.org/about-ghrsst/governance-documents/
+
+"""
+
+from datetime import datetime
+import collections
+
+import numpy as np
+import iris
+
+from forest import geo
+
+
+def empty_image():
+    return {
+        "x": [],
+        "y": [],
+        "dw": [],
+        "dh": [],
+        "image": [],
+        "name": [],
+        "units": [],
+        "valid": [],
+        "initial": [],
+        "length": [],
+        "level": []
+    }
+
+
+def _to_datetime(d):
+    if isinstance(d, datetime):
+        return d
+    elif isinstance(d, str):
+        try:
+            return datetime.strptime(d, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
+    elif isinstance(d, np.datetime64):
+        return d.astype(datetime)
+    else:
+        raise Exception("Unknown value: {}".format(d))
+
+
+def coordinates(valid_time, initial_time, pressures, pressure):
+    valid = _to_datetime(valid_time)
+    initial = _to_datetime(initial_time)
+    hours = (valid - initial).total_seconds() / (60*60)
+    length = "T{:+}".format(int(hours))
+    level = "Sea Surface"
+    return {
+        'valid': [valid],
+        'initial': [initial],
+        'length': [length],
+        'level': [level]
+    }
+
+
+def _is_valid_cube(cube):
+    """Return True if, and only if, the cube conforms to a GHRSST data specification"""
+    attributes = cube.metadata.attributes
+    return ( "GDS_version_id" in attributes) or ("gds_version_id" in attributes)
+
+# TODO: This logic should move to a "Group" concept.
+def _load(pattern):
+    """Return all the valid GHRSST L4 cubes that can be loaded
+    from the given filename pattern."""
+    cubes = iris.load(pattern)
+
+    # Ensure that we only retain cubes that meet our entry criteria
+    # for "gridded forecast"
+    cubes = list(filter(_is_valid_cube, cubes))
+    assert len(cubes) > 0
+
+    # Find all the names with duplicates
+    name_counts = collections.Counter(cube.name() for cube in cubes)
+    duplicate_names = {name for name, count in name_counts.items()
+                       if count > 1}
+
+    # Map names (with numeric suffixes for duplicates) to cubes
+    duplicate_counts = collections.defaultdict(int)
+    cube_mapping = {}
+    for cube in cubes:
+        name = cube.name()
+        if name in duplicate_names:
+            duplicate_counts[name] += 1
+            name += f' ({duplicate_counts[name]})'
+        cube_mapping[name] = cube
+    return cube_mapping
+
+
+class ImageLoader:
+    def __init__(self, label, pattern):
+        self._label = label
+        self._cubes = _load(pattern)
+
+    def image(self, state):
+        cube = self._cubes[state.variable]
+        valid_datetime = _to_datetime(state.valid_time)
+        cube = cube.extract(iris.Constraint(time=valid_datetime))
+
+        if cube is None:
+            data = empty_image()
+        else:
+            data = geo.stretch_image(cube.coord('longitude').points,
+                                     cube.coord('latitude').points, cube.data)
+            data.update(coordinates(state.valid_time, state.initial_time,
+                                    state.pressures, state.pressure))
+            data.update({
+                'name': [self._label],
+                'units': [str(cube.units)]
+            })
+        return data
+
+
+class Navigator:
+    def __init__(self, paths):
+        self._cubes = _load(paths)
+
+    def variables(self, pattern):
+        return list(self._cubes.keys())
+
+    def initial_times(self, pattern, variable=None):
+        return list([datetime(1970,1,1)])
+
+    def valid_times(self, pattern, variable, initial_time):
+        cube = self._cubes[variable]
+        return [cell.point for cell in cube.coord('time').cells()]
+
+    def pressures(self, pattern, variable, initial_time):
+        pressures = []
+        return pressures

--- a/forest/ghrsstl4.py
+++ b/forest/ghrsstl4.py
@@ -63,7 +63,12 @@ def coordinates(valid_time, initial_time, pressures, pressure):
 def _is_valid_cube(cube):
     """Return True if, and only if, the cube conforms to a GHRSST data specification"""
     attributes = cube.metadata.attributes
-    return ( "GDS_version_id" in attributes) or ("gds_version_id" in attributes)
+    is_gds = ("GDS_version_id" in attributes) or ("gds_version_id" in attributes)
+    dim_names = [c.name() for c in cube.dim_coords]
+    contains_dims = {'time', 'latitude', 'longitude'}.issubset(set(dim_names))
+    dims_are_ordered = dim_names[:3] == ['time', 'latitude', 'longitude']
+    has_3_dims = len(dim_names) == 3
+    return is_gds and contains_dims and dims_are_ordered and has_3_dims
 
 # TODO: This logic should move to a "Group" concept.
 def _load(pattern):

--- a/forest/load.py
+++ b/forest/load.py
@@ -26,6 +26,7 @@ from forest import (
         db,
         earth_networks,
         gridded_forecast,
+        ghrsstl4,
         unified_model,
         rdt,
         satellite)
@@ -131,6 +132,7 @@ class Loader(object):
     @staticmethod
     def file_loader(file_type, pattern, label=None, locator=None):
         file_type = file_type.lower().replace("_", "")
+        print(file_type)
         if file_type == 'rdt':
             return rdt.Loader(pattern)
         elif file_type == 'gpm':
@@ -141,6 +143,8 @@ class Loader(object):
             return satellite.EIDA50(pattern)
         elif file_type == 'griddedforecast':
             return gridded_forecast.ImageLoader(label, pattern)
+        elif file_type == 'ghrsstl4':
+            return ghrsstl4.ImageLoader(label, pattern)
         elif file_type == 'unifiedmodel':
             return data.DBLoader(label, pattern, locator)
         else:

--- a/forest/main.py
+++ b/forest/main.py
@@ -1,6 +1,7 @@
 import bokeh.plotting
 import bokeh.models
 import bokeh.events
+import bokeh.colors
 import numpy as np
 import os
 import glob
@@ -685,6 +686,8 @@ class MapperLimits(object):
             high = np.max([np.max(x) for x in images])
             self.color_mapper.low = low
             self.color_mapper.high = high
+            self.color_mapper.low_color = bokeh.colors.RGB(0, 0, 0, a=0)
+            self.color_mapper.high_color = bokeh.colors.RGB(0, 0, 0, a=0)
 
     @staticmethod
     def change(widget, prop, dtype):

--- a/forest/navigate.py
+++ b/forest/navigate.py
@@ -8,6 +8,7 @@ from .exceptions import (
         PressuresNotFound)
 from forest import (
         gridded_forecast,
+        ghrsstl4,
         unified_model,
         eida50,
         rdt)
@@ -64,6 +65,8 @@ class FileSystem(object):
         elif file_type.lower() == 'griddedforecast':
             # XXX This needs a "Group" object ... not "paths"
             return gridded_forecast.Navigator(paths)
+        elif file_type.lower() == 'ghrsstl4':
+            return ghrsstl4.Navigator(paths)
         elif file_type.lower() == "unified_model":
             coordinates = unified_model.Coordinates()
         else:

--- a/test/test_ghrsstl4.py
+++ b/test/test_ghrsstl4.py
@@ -1,0 +1,269 @@
+from datetime import datetime
+from unittest.mock import Mock, call, patch, sentinel
+import unittest
+
+import iris
+import numpy as np
+
+from forest import ghrsstl4
+
+
+class Test_empty_image(unittest.TestCase):
+    def test(self):
+        result = ghrsstl4.empty_image()
+        self.assertEqual(result.keys(), {'x', 'y', 'dw', 'dh', 'image', 'name',
+                                         'units', 'valid', 'initial', 'length',
+                                         'level'})
+        for value in result.values():
+            self.assertEqual(value, [])
+
+
+class Test_to_datetime(unittest.TestCase):
+    def test_datetime(self):
+        dt = datetime.now()
+        result = ghrsstl4._to_datetime(dt)
+        self.assertEqual(result, dt)
+
+    def test_str_with_space(self):
+        result = ghrsstl4._to_datetime('2019-10-10 01:02:34')
+        self.assertEqual(result, datetime(2019, 10, 10, 1, 2, 34))
+
+    def test_str_iso8601(self):
+        result = ghrsstl4._to_datetime('2019-10-10T01:02:34')
+        self.assertEqual(result, datetime(2019, 10, 10, 1, 2, 34))
+
+    def test_datetime64(self):
+        dt = np.datetime64('2019-10-10T11:22:33')
+        result = ghrsstl4._to_datetime(dt)
+        self.assertEqual(result, datetime(2019, 10, 10, 11, 22, 33))
+
+    def test_unsupported(self):
+        with self.assertRaisesRegexp(Exception, 'Unknown value'):
+            ghrsstl4._to_datetime(12)
+
+
+@patch('forest.ghrsstl4._to_datetime')
+class Test_coordinates(unittest.TestCase):
+    def test_surface_and_times(self, to_datetime):
+        valid = datetime(2019, 10, 10, 9)
+        initial = datetime(2019, 10, 10, 3)
+        to_datetime.side_effect = [valid, initial]
+
+        result = ghrsstl4.coordinates(sentinel.valid, sentinel.initial,
+                                              [], None)
+
+        self.assertEqual(to_datetime.mock_calls, [call(sentinel.valid),
+                                                  call(sentinel.initial)])
+        self.assertEqual(result, {'valid': [valid], 'initial': [initial],
+                                  'length': ['T+6'], 'level': ['Sea Surface']})
+
+    def test_surface_no_pressures(self, to_datetime):
+        result = ghrsstl4.coordinates(None, None, [], 950)
+
+        self.assertEqual(result['level'], ['Sea Surface'])
+
+    def test_surface_no_pressure(self, to_datetime):
+        result = ghrsstl4.coordinates(None, None, [1000, 900], None)
+
+        self.assertEqual(result['level'], ['Sea Surface'])
+
+class Test_is_valid_cube(unittest.TestCase):
+    def setUp(self):
+        lon = iris.coords.DimCoord(range(5), 'longitude')
+        lat = iris.coords.DimCoord(range(4), 'latitude')
+        time = iris.coords.DimCoord(range(3), 'time')
+        other = iris.coords.DimCoord(range(2), long_name='other')
+        cube = iris.cube.Cube(np.empty((2, 3, 4, 5)), 'sea_surface_foundation_temperature',
+                              dim_coords_and_dims=[(other, 0), (time, 1),
+                                                   (lat, 2), (lon, 3)],
+                              attributes={"gds_version_id": 2.0})
+        self.cube = cube
+
+    def test_ok(self):
+        cube = self.cube[0]
+        self.assertTrue(ghrsstl4._is_valid_cube(cube))
+
+    def test_1d(self):
+        cube = self.cube[0, 0, 0]
+        self.assertFalse(ghrsstl4._is_valid_cube(cube))
+
+    def test_4d(self):
+        cube = self.cube
+        self.assertFalse(ghrsstl4._is_valid_cube(cube))
+
+    def test_2d_missing_time_coord(self):
+        cube = self.cube[0, 0]
+        cube.remove_coord(cube.coord('time'))
+        self.assertFalse(ghrsstl4._is_valid_cube(cube))
+
+    def test_missing_dim_coord(self):
+        cube = self.cube[0]
+        cube.remove_coord(cube.dim_coords[0])
+        self.assertFalse(ghrsstl4._is_valid_cube(cube))
+
+    def test_invalid_dim_coord(self):
+        cube = self.cube[0]
+        cube.dim_coords[2].rename('projection_x_coordinate')
+        self.assertFalse(ghrsstl4._is_valid_cube(cube))
+
+    def test_transposed(self):
+        cube = self.cube[0]
+        cube.transpose()
+        self.assertFalse(ghrsstl4._is_valid_cube(cube))
+
+
+class Test_load(unittest.TestCase):
+    @patch('forest.ghrsstl4._is_valid_cube')
+    @patch('iris.load')
+    def test_all_unique(self, load, is_valid_cube):
+        cube1 = Mock(**{'name.return_value': 'foo'})
+        cube2 = Mock(**{'name.return_value': 'bar'})
+        load.return_value = [cube1, cube2]
+        is_valid_cube.return_value = True
+
+        result = ghrsstl4._load(sentinel.pattern)
+
+        load.assert_called_once_with(sentinel.pattern)
+        self.assertEqual(is_valid_cube.mock_calls, [call(cube1), call(cube2)])
+        self.assertEqual(result, {'foo': cube1, 'bar': cube2})
+
+    @patch('forest.ghrsstl4._is_valid_cube')
+    @patch('iris.load')
+    def test_duplicate_name(self, load, is_valid_cube):
+        cube1 = Mock(**{'name.return_value': 'foo'})
+        cube2 = Mock(**{'name.return_value': 'foo'})
+        load.return_value = [cube1, cube2]
+        is_valid_cube.return_value = True
+
+        result = ghrsstl4._load(sentinel.pattern)
+
+        load.assert_called_once_with(sentinel.pattern)
+        self.assertEqual(is_valid_cube.mock_calls, [call(cube1), call(cube2)])
+        self.assertEqual(result, {'foo (1)': cube1, 'foo (2)': cube2})
+
+    @patch('forest.ghrsstl4._is_valid_cube')
+    @patch('iris.load')
+    def test_none_valid(self, load, is_valid_cube):
+        load.return_value = ['foo', 'bar']
+        is_valid_cube.return_value = False
+
+        with self.assertRaises(AssertionError):
+            ghrsstl4._load(None)
+
+
+class Test_ImageLoader(unittest.TestCase):
+    @patch('forest.ghrsstl4._load')
+    def test_init(self, load):
+        load.return_value = sentinel.cubes
+        result = ghrsstl4.ImageLoader(sentinel.label, sentinel.pattern)
+        load.assert_called_once_with(sentinel.pattern)
+        self.assertEqual(result._label, sentinel.label)
+        self.assertEqual(result._cubes, sentinel.cubes)
+
+    @patch('forest.ghrsstl4.empty_image')
+    @patch('iris.Constraint')
+    @patch('forest.ghrsstl4._to_datetime')
+    def test_empty(self, to_datetime, constraint, empty_image):
+        # To avoid re-testing the constructor, just make a fake ImageLoader
+        # instance.
+        original_cube = Mock()
+        original_cube.extract.return_value = None
+        image_loader = Mock(_cubes={'foo': original_cube})
+
+        to_datetime.return_value = sentinel.valid_datetime
+        constraint.return_value = sentinel.constraint
+        empty_image.return_value = sentinel.empty_image
+
+        result = ghrsstl4.ImageLoader.image(
+            image_loader, Mock(variable='foo', valid_time=sentinel.valid))
+
+        to_datetime.assert_called_once_with(sentinel.valid)
+        constraint.assert_called_once_with(time=sentinel.valid_datetime)
+        original_cube.extract.assert_called_once_with(sentinel.constraint)
+        self.assertEqual(result, sentinel.empty_image)
+
+    @patch('forest.ghrsstl4.coordinates')
+    @patch('forest.geo.stretch_image')
+    @patch('iris.Constraint')
+    @patch('forest.ghrsstl4._to_datetime')
+    def test_image(self, to_datetime, constraint, stretch_image, coordinates):
+        # To avoid re-testing the constructor, just make a fake ImageLoader
+        # instance.
+        cube = Mock()
+        cube.coord.side_effect = [Mock(points=sentinel.longitudes),
+                                  Mock(points=sentinel.latitudes)]
+        cube.units.__str__ = lambda self: 'my-units'
+        original_cube = Mock()
+        original_cube.extract.return_value = cube
+        image_loader = Mock(_cubes={'foo': original_cube}, _label='my-label')
+
+        to_datetime.return_value = sentinel.valid_datetime
+        constraint.return_value = sentinel.constraint
+        stretch_image.return_value = {'stretched_image': True}
+        coordinates.return_value = {'coordinates': True}
+
+        result = ghrsstl4.ImageLoader.image(
+            image_loader, Mock(variable='foo', valid_time=sentinel.valid,
+                               initial_time=sentinel.initial,
+                               pressures=sentinel.pressures,
+                               pressure=sentinel.pressure))
+
+        self.assertEqual(cube.coord.mock_calls, [call('longitude'),
+                                                 call('latitude')])
+        stretch_image.assert_called_once_with(sentinel.longitudes,
+                                              sentinel.latitudes, cube.data)
+        coordinates.assert_called_once_with(sentinel.valid, sentinel.initial,
+                                            sentinel.pressures,
+                                            sentinel.pressure)
+        self.assertEqual(result, {'stretched_image': True, 'coordinates': True,
+                                  'name': ['my-label'], 'units': ['my-units']})
+
+
+class Test_Navigator(unittest.TestCase):
+    @patch('forest.ghrsstl4._load')
+    def test_init(self, load):
+        load.return_value = sentinel.cubes
+        result = ghrsstl4.Navigator(sentinel.paths)
+        load.assert_called_once_with(sentinel.paths)
+        self.assertEqual(result._cubes, sentinel.cubes)
+
+    def test_variables(self):
+        navigator = Mock(_cubes={'one': 1, 'two': 2, 'three': 3})
+        result = ghrsstl4.Navigator.variables(navigator, None)
+        self.assertEqual(list(sorted(result)), ['one', 'three', 'two'])
+
+    def test_initial_times(self):
+        cube1 = Mock()
+        cube2 = Mock()
+        cube3 = Mock()
+        navigator = Mock()
+        navigator._cubes.values.return_value = [cube1, cube2, cube3]
+
+        result = ghrsstl4.Navigator.initial_times(navigator, None,
+                                                          None)
+        res_strs = [r.strftime("%Y-%m-%d") for r in result]
+        self.assertEqual(res_strs, ['1970-01-01'])
+
+    def test_valid_times(self):
+        cube1 = Mock()
+        cube1.coord.return_value.cells.return_value = [Mock(point='p1'),
+                                                       Mock(point='p2')]
+        navigator = Mock()
+        navigator._cubes = {'first': cube1, 'second': None}
+
+        result = ghrsstl4.Navigator.valid_times(navigator, None,
+                                                        'first', None)
+
+        cube1.coord.assert_called_once_with('time')
+        self.assertEqual(result, ['p1', 'p2'])
+
+    def test_pressures_empty(self):
+        cube1 = Mock()
+        cube1.coord.side_effect = iris.exceptions.CoordinateNotFoundError
+        navigator = Mock()
+        navigator._cubes = {'first': cube1, 'second': None}
+
+        result = ghrsstl4.Navigator.pressures(navigator, None,
+                                                        'first', None)
+
+        self.assertEqual(result, [])


### PR DESCRIPTION
This is some work I did as part of the hackathon adding some basic support for reading sea surface temperature analysis data from the [GHRSST project](www.ghrsst.org). The main changes are in `ghrsstl4.py` and I have added some tests in `test_ghrsstl4.py` (pretty much copied from `gridded_forecast.py` and `test_gridded_forecast.py`).

I have altered `geo.py` so that any mask on the data is preserved in `stretch_image`.

To test, I have been running:
`forest --show --file-type ghrsstl4 20190918120000-UKMO-L4_GHRSST-SSTfnd-OSTIA-GLOB-v02.0-fv02.0.nc`

OSTIA data ought to conform to the [GHRSST data specification](https://www.ghrsst.org/about-ghrsst/governance-documents/), but there a few other level 4 analyses available from other met centres which also seem to plot OK (GAMSSA and OSPO_night are two others I checked).

### Issues
  * These are not forecasts, so I set forecast time to 1970-01-01, but this is a bit ugly
  * The colour bars start from the missing data indicator values rather than the beginning of the real data. I haven't been able to work out what is doing this yet.
  * Many, many others I didn't notice :)