### PR TITLE
Go tool

### DIFF
--- a/server/forest-upload/Makefile
+++ b/server/forest-upload/Makefile
@@ -1,0 +1,2 @@
+build:
+	go build -ldflags "-X main.endpoint=${ENDPOINT}"

--- a/server/forest-upload/Makefile
+++ b/server/forest-upload/Makefile
@@ -1,2 +1,7 @@
+BINARY=forest-upload
+
+all: build build-linux
 build:
 	go build -ldflags "-X main.endpoint=${ENDPOINT}"
+build-linux:
+	GOOS=linux go build -o ${BINARY}-linux -ldflags "-X main.endpoint=${ENDPOINT}"

--- a/server/forest-upload/README.md
+++ b/server/forest-upload/README.md
@@ -1,0 +1,7 @@
+# Prototype file transfer tool
+
+Ideas for transfering files to S3 using pre-signed URLs
+
+```bash
+make build ENDPOINT=https://...amazonaws.com/lambda
+```

--- a/server/forest-upload/README.md
+++ b/server/forest-upload/README.md
@@ -27,5 +27,5 @@ to use the tool.
 forest-upload *.nc
 ```
 
-*Note:* Large file transfer is not supported. The whole file is read into memory
-        prior to upload.
+**Note:** Multi-part upload is not supported. The whole file is
+read into memory prior to upload.

--- a/server/forest-upload/README.md
+++ b/server/forest-upload/README.md
@@ -1,7 +1,31 @@
-# Prototype file transfer tool
+# FOREST collaboration file transfer tool
 
-Ideas for transfering files to S3 using pre-signed URLs
+Transfer files to S3 using pre-signed URLs. This facility
+enables collaborators to send small files to a dedicated
+S3 bucket.
+
+## Build process
+
+The REST endpoint that generates pre-signed URLs can
+be specified at compile time to reduce complexity
+on the end user.
 
 ```bash
 make build ENDPOINT=https://...amazonaws.com/lambda
 ```
+
+## Usage
+
+The REST endpoint is secured using API keys. Instructions
+on how to use and store your API key should be made
+available to you by an administrator. Once your
+environment has been configured it is fairly simple
+to use the tool.
+
+```bash
+# Upload multiple NetCDF files
+forest-upload *.nc
+```
+
+*Note:* Large file transfer is not supported. The whole file is read into memory
+        prior to upload.

--- a/server/forest-upload/README.md
+++ b/server/forest-upload/README.md
@@ -14,6 +14,9 @@ on the end user.
 make build ENDPOINT=https://...amazonaws.com/lambda
 ```
 
+**Note:** If the ENDPOINT is not specified at compile
+time the application will fail to operate
+
 ## Usage
 
 The REST endpoint is secured using API keys. Instructions

--- a/server/forest-upload/main.go
+++ b/server/forest-upload/main.go
@@ -68,7 +68,7 @@ func main() {
 			fmt.Printf("pre-signed URL generation failed: %s\n", fileName)
 			log.Fatal(err)
 		}
-		signed, err := parseResponseBody(content)
+		signed, err := parseResponse(content)
 		if err != nil {
 			fmt.Printf("Could not parse response: %s\n", string(content))
 			log.Fatal(err)
@@ -161,13 +161,17 @@ func apiKeyGet(url, key string) ([]byte, error) {
 	return content, nil
 }
 
-func parseResponseBody(content []byte) (SignedURL, error) {
+func parseResponse(content []byte) (SignedURL, error) {
 	var data interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return SignedURL{}, err
 	}
 	mapping := data.(map[string]interface{})
+	if mapping["body"] == nil {
+		message := fmt.Sprintf("Could not parse: %s", content)
+		return SignedURL{}, errors.New(message)
+	}
 	body := mapping["body"].(string)
 
 	var bodyData interface{}

--- a/server/forest-upload/main.go
+++ b/server/forest-upload/main.go
@@ -70,6 +70,7 @@ func main() {
 		}
 		signed, err := parseResponseBody(content)
 		if err != nil {
+			fmt.Printf("Could not parse response: %s\n", string(content))
 			log.Fatal(err)
 		}
 		err = fileUpload(fileName, signed.url, signed.fields)

--- a/server/forest-upload/main.go
+++ b/server/forest-upload/main.go
@@ -24,6 +24,9 @@ type SignedURL struct {
 // use go build -ldflags "-X main.endpoint=$ENDPOINT"
 var endpoint string
 
+// Debug setting to help developers see response contents
+var debug bool = false
+
 type Namespace struct {
 	APIKey    string
 	fileNames []string
@@ -73,6 +76,11 @@ func main() {
 			fmt.Printf("Could not parse response: %s\n", string(content))
 			log.Fatal(err)
 		}
+		if debug {
+			fmt.Printf("upload: %s to %s\n", fileName, signed.url)
+		} else {
+			fmt.Printf("upload: %s to S3 bucket\n", fileName)
+		}
 		err = fileUpload(fileName, signed.url, signed.fields)
 		if err != nil {
 			log.Fatal(err)
@@ -81,8 +89,6 @@ func main() {
 }
 
 func fileUpload(fileName string, url string, params map[string]string) error {
-	fmt.Printf("upload: %s to %s\n", fileName, url)
-
 	// Read/write buffer to store file content
 	rw := &bytes.Buffer{}
 
@@ -136,7 +142,7 @@ func fileUpload(fileName string, url string, params map[string]string) error {
 			return err
 		}
 		response.Body.Close()
-		if true {
+		if debug {
 			fmt.Println(response.StatusCode)
 			fmt.Println(response.Header)
 			fmt.Println(body)

--- a/server/forest-upload/main.go
+++ b/server/forest-upload/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/cheggaaa/pb/v3"
+	"io"
+	"io/ioutil"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+)
+
+type SignedURL struct {
+	url    string
+	fields map[string]string
+}
+
+// Compile-time variable hidden from end-user
+// use go build -ldflags "-X main.endpoint=$ENDPOINT"
+var endpoint string
+
+type Namespace struct {
+	APIKey    string
+	fileNames []string
+}
+
+func parseArgs(argc []string) (Namespace, error) {
+	flagSet := flag.NewFlagSet(argc[0], flag.ContinueOnError)
+	APIKey, ok := os.LookupEnv("FOREST_API_KEY")
+	if !ok {
+		return Namespace{}, errors.New("FOREST_API_KEY environment variable not set")
+	}
+	err := flagSet.Parse(argc[1:])
+	if err != nil {
+		return Namespace{}, err
+	}
+	return Namespace{APIKey, flagSet.Args()}, nil
+}
+
+func Usage() {
+	fmt.Printf("Usage: %s FILE [FILE ...]]\n", os.Args[0])
+}
+
+func main() {
+	if endpoint == "" {
+		log.Println("REST endpoint not specified during compilation")
+		log.Fatalln("Contact an administrator")
+	}
+	args, err := parseArgs(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if args.APIKey == "" {
+		Usage()
+		fmt.Println("Please specify FOREST_API_KEY environment variable")
+		return
+	}
+	if len(args.fileNames) == 0 {
+		Usage()
+		fmt.Println("Too few arguments specified")
+		return
+	}
+	for _, fileName := range args.fileNames {
+		fmt.Printf("pre-sign URL: %s\n", fileName)
+		signed, err := presignedURL(endpoint, fileName)
+		if err != nil {
+			fmt.Printf("pre-signed URL generation failed: %s\n", fileName)
+			log.Fatal(err)
+		}
+		err = fileUpload(fileName, signed.url, signed.fields)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func fileUpload(fileName string, url string, params map[string]string) error {
+	fmt.Printf("upload: %s to %s\n", fileName, url)
+
+	// Read/write buffer to store file content
+	rw := &bytes.Buffer{}
+
+	// Multipart Writer
+	writer := multipart.NewWriter(rw)
+
+	// Add pre-signed form-fields
+	for k, v := range params {
+		writer.WriteField(k, v)
+	}
+
+	// Add file form-field at the end (AWS peculiarity)
+	part, err := writer.CreateFormFile("file", fileName)
+	if err != nil {
+		return err
+	}
+
+	// Open file
+	reader, err := os.Open(fileName)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	// File size in bytes
+	info, err := reader.Stat()
+	if err != nil {
+		return err
+	}
+	fileSize64 := info.Size()
+
+	// Progress bar
+	bar := pb.Full.Start(int(fileSize64))
+	barReader := bar.NewProxyReader(reader)
+
+	// Copy file using multipart.Writer
+	if _, err = io.Copy(part, barReader); err != nil {
+		return err
+	}
+	writer.Close()
+	bar.Finish()
+
+	// POST request and Println response (consider refactor)
+	response, err := http.Post(url, writer.FormDataContentType(), rw)
+	if err != nil {
+		return err
+	} else {
+		body := &bytes.Buffer{}
+		_, err := body.ReadFrom(response.Body)
+		if err != nil {
+			return err
+		}
+		response.Body.Close()
+		if true {
+			fmt.Println(response.StatusCode)
+			fmt.Println(response.Header)
+			fmt.Println(body)
+		}
+	}
+	return nil
+}
+
+func presignedURL(endpoint, fileName string) (SignedURL, error) {
+	// Ask Lambda for pre-signed URL and parse response
+	url := endpoint + "?file=" + fileName
+	res, err := http.Get(url)
+	if err != nil {
+		return SignedURL{}, err
+	}
+	defer res.Body.Close()
+	content, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return SignedURL{}, err
+	}
+	var data interface{}
+	err = json.Unmarshal(content, &data)
+	if err != nil {
+		return SignedURL{}, err
+	}
+	mapping := data.(map[string]interface{})
+	body := mapping["body"].(string)
+
+	var bodyData interface{}
+	err = json.Unmarshal([]byte(body), &bodyData)
+	if err != nil {
+		return SignedURL{}, err
+	}
+	b := bodyData.(map[string]interface{})
+	s3url := b["url"].(string)
+	fields := b["fields"].(map[string]interface{})
+	s3fields := make(map[string]string)
+	for k, v := range fields {
+		s3fields[k] = v.(string)
+	}
+	return SignedURL{s3url, s3fields}, nil
+}

--- a/server/forest-upload/main_test.go
+++ b/server/forest-upload/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseArgs(t *testing.T) {
+	t.Run("given environment variable", func(t *testing.T) {
+		key := "ABC"
+		os.Setenv("FOREST_API_KEY", key)
+		got, err := parseArgs([]string{"file.nc"})
+		if err != nil {
+			t.Errorf("got error: %s", err)
+		}
+		if got.APIKey != key {
+			t.Errorf("want %s got %s", key, got.APIKey)
+		}
+	})
+
+	t.Run("without api key environment variable", func(t *testing.T) {
+		os.Unsetenv("FOREST_API_KEY")
+		_, err := parseArgs([]string{"file.nc"})
+		if err == nil {
+			t.Error("expect error to be raised")
+		}
+	})
+
+}

--- a/server/forest-upload/main_test.go
+++ b/server/forest-upload/main_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+func TestURL(t *testing.T) {
+}
+
 func TestParseArgs(t *testing.T) {
 	t.Run("given environment variable", func(t *testing.T) {
 		key := "ABC"

--- a/server/forest-upload/main_test.go
+++ b/server/forest-upload/main_test.go
@@ -5,7 +5,13 @@ import (
 	"testing"
 )
 
-func TestURL(t *testing.T) {
+func TestParseResponse(t *testing.T) {
+	t.Run("given empty JSON object returns error", func(t *testing.T) {
+		_, err := parseResponse([]byte("{}"))
+		if err == nil {
+			t.Error("want error got nil")
+		}
+	})
 }
 
 func TestParseArgs(t *testing.T) {


### PR DESCRIPTION

First draft of the collaboration upload tool. There are probably more features and tests to add, but a wise man once said, "Bank progress". So here is a pull request to get this tool in to the code base.

- Manual build process `make ENDPOINT=https://{restapi_id}.execute-api.{region}.amazonaws.com/{stage_name}/` hidden from end-user allows us to design our own REST API communication
- Use `FOREST_API_KEY` environment variable to allow user to hide their secret API key somewhere, it is not an explicit `-api-key` command line argument
- Call signature `forest-upload FILE [FILE ...]` makes it easy to use. We decide how to store/pre-process files that get sent to us