### PR TITLE
Fix lambda permissions

### DIFF
--- a/server/forest-upload/Makefile
+++ b/server/forest-upload/Makefile
@@ -1,5 +1,6 @@
 BINARY=forest-upload
-LDFLAGS="-X main.endpoint=${ENDPOINT}"
+VERSION=0.1.1
+LDFLAGS="-X main.endpoint=${ENDPOINT} -X main.version=${VERSION}"
 
 all: build build-linux
 build:

--- a/server/forest-upload/Makefile
+++ b/server/forest-upload/Makefile
@@ -1,7 +1,8 @@
 BINARY=forest-upload
+LDFLAGS="-X main.endpoint=${ENDPOINT}"
 
 all: build build-linux
 build:
-	go build -ldflags "-X main.endpoint=${ENDPOINT}"
+	go build -ldflags ${LDFLAGS}
 build-linux:
-	GOOS=linux go build -o ${BINARY}-linux -ldflags "-X main.endpoint=${ENDPOINT}"
+	GOOS=linux go build -o ${BINARY}-linux -ldflags ${LDFLAGS}

--- a/server/forest-upload/README.md
+++ b/server/forest-upload/README.md
@@ -17,6 +17,15 @@ make build ENDPOINT=https://...amazonaws.com/lambda
 **Note:** If the ENDPOINT is not specified at compile
 time the application will fail to operate
 
+## Version
+
+To make it easier to see which version of the app you are using
+run
+
+```bash
+forest-upload -version
+```
+
 ## Usage
 
 The REST endpoint is secured using API keys. Instructions

--- a/server/forest-upload/main.go
+++ b/server/forest-upload/main.go
@@ -20,7 +20,7 @@ import (
 var endpoint string
 
 // Debug setting to help developers see response contents
-var debug bool = true
+var debug bool = false
 
 type Namespace struct {
 	APIKey    string
@@ -76,7 +76,6 @@ func main() {
 		} else {
 			fmt.Printf("upload: %s to S3 bucket\n", fileName)
 		}
-		fmt.Println(signed.Fields)
 		err = fileUpload(fileName, signed.URL, signed.Fields)
 		if err != nil {
 			log.Fatal(err)

--- a/server/forest-upload/main_test.go
+++ b/server/forest-upload/main_test.go
@@ -1,15 +1,36 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 )
 
 func TestParseResponse(t *testing.T) {
-	t.Run("given empty JSON object returns error", func(t *testing.T) {
-		_, err := parseResponse([]byte("{}"))
-		if err == nil {
-			t.Error("want error got nil")
+	t.Run("given empty JSON object returns empty struct", func(t *testing.T) {
+		resp, _ := parseResponse([]byte("{}"))
+		if resp.URL != "" {
+			t.Error("Should get empty URL")
+		}
+	})
+
+	t.Run("urls/fields", func(t *testing.T) {
+		url := "s3-bucket.url"
+		fields := map[string]string{"key": "value"}
+		resp := Response{url, fields}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			t.Error(err)
+		}
+		signed, err := parseResponse(b)
+		if err != nil {
+			t.Error(err)
+		}
+		if signed.URL != url {
+			t.Errorf("want %s got %s", url, signed.URL)
+		}
+		if signed.Fields["key"] != fields["key"] {
+			t.Errorf("want %s got %s", fields, signed.Fields)
 		}
 	})
 }

--- a/server/forest-upload/main_test.go
+++ b/server/forest-upload/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 )
 
@@ -36,24 +35,23 @@ func TestParseResponse(t *testing.T) {
 }
 
 func TestParseArgs(t *testing.T) {
-	t.Run("given environment variable", func(t *testing.T) {
-		key := "ABC"
-		os.Setenv("FOREST_API_KEY", key)
-		got, err := parseArgs([]string{"file.nc"})
+	t.Run("file(s)", func(t *testing.T) {
+		args, err := parseArgs([]string{"cmd", "file.nc"})
 		if err != nil {
 			t.Errorf("got error: %s", err)
 		}
-		if got.APIKey != key {
-			t.Errorf("want %s got %s", key, got.APIKey)
+		if len(args.fileNames) != 1 {
+			t.Errorf("got: %s", args.fileNames)
 		}
 	})
 
-	t.Run("without api key environment variable", func(t *testing.T) {
-		os.Unsetenv("FOREST_API_KEY")
-		_, err := parseArgs([]string{"file.nc"})
-		if err == nil {
-			t.Error("expect error to be raised")
+	t.Run("-version", func(t *testing.T) {
+		args, err := parseArgs([]string{"cmd", "-version"})
+		if err != nil {
+			t.Errorf("got error: %s", err)
+		}
+		if args.version != true {
+			t.Errorf("want %t got %t", true, args.version)
 		}
 	})
-
 }

--- a/stack/app-stack.yaml
+++ b/stack/app-stack.yaml
@@ -187,44 +187,23 @@ Resources:
                   content:
                     application/json:
                       schema:
-                        $ref: "#components/schemas/Presign"
+                        type: string
+              security:
+              - api_key: []
               x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                contentHandling: "CONVERT_TO_TEXT"
                 uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${ProjectName}-${UniqueEnvName}-${AWS::Region}-lambda/invocations"
                 responses:
                   default:
                     statusCode: "200"
-                requestParameters:
-                  integration.request.querystring.file: "method.request.querystring.file"
-                passthroughBehavior: "when_no_match"
-                httpMethod: "POST"
                 requestTemplates:
-                  application/json: "##  See http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html\n\
-                    ##  This template will pass through all parameters including path, querystring,\
-                    \ header, stage variables, and context through to the integration endpoint\
-                    \ via the body/payload\n#set($allParams = $input.params())\n{\n\"body-json\"\
-                    \ : $input.json('$'),\n\"params\" : {\n#foreach($type in $allParams.keySet())\n\
-                    \    #set($params = $allParams.get($type))\n\"$type\" : {\n    #foreach($paramName\
-                    \ in $params.keySet())\n    \"$paramName\" : \"$util.escapeJavaScript($params.get($paramName))\"\
-                    \n        #if($foreach.hasNext),#end\n    #end\n}\n    #if($foreach.hasNext),#end\n\
-                    #end\n},\n\"stage-variables\" : {\n#foreach($key in $stageVariables.keySet())\n\
-                    \"$key\" : \"$util.escapeJavaScript($stageVariables.get($key))\"\n   \
-                    \ #if($foreach.hasNext),#end\n#end\n},\n\"context\" : {\n    \"account-id\"\
-                    \ : \"$context.identity.accountId\",\n    \"api-id\" : \"$context.apiId\"\
-                    ,\n    \"api-key\" : \"$context.identity.apiKey\",\n    \"authorizer-principal-id\"\
-                    \ : \"$context.authorizer.principalId\",\n    \"caller\" : \"$context.identity.caller\"\
-                    ,\n    \"cognito-authentication-provider\" : \"$context.identity.cognitoAuthenticationProvider\"\
-                    ,\n    \"cognito-authentication-type\" : \"$context.identity.cognitoAuthenticationType\"\
-                    ,\n    \"cognito-identity-id\" : \"$context.identity.cognitoIdentityId\"\
-                    ,\n    \"cognito-identity-pool-id\" : \"$context.identity.cognitoIdentityPoolId\"\
-                    ,\n    \"http-method\" : \"$context.httpMethod\",\n    \"stage\" : \"\
-                    $context.stage\",\n    \"source-ip\" : \"$context.identity.sourceIp\"\
-                    ,\n    \"user\" : \"$context.identity.user\",\n    \"user-agent\" : \"\
-                    $context.identity.userAgent\",\n    \"user-arn\" : \"$context.identity.userArn\"\
-                    ,\n    \"request-id\" : \"$context.requestId\",\n    \"resource-id\" :\
-                    \ \"$context.resourceId\",\n    \"resource-path\" : \"$context.resourcePath\"\
-                    \n    }\n}\n"
-                contentHandling: "CONVERT_TO_TEXT"
-                type: "aws"
+                  application/json: |
+                    {
+                      "body": "$input.json('$')",
+                      "params": "$input.params()"
+                    }
         components:
           securitySchemes:
             api_key:

--- a/stack/app-stack.yaml
+++ b/stack/app-stack.yaml
@@ -84,7 +84,8 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${ProjectName}-${UniqueEnvName}-${AWS::Region}-lambda"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${ProjectName}-${UniqueEnvName}-${AWS::Region}-lambda:*"
-                  - !GetAtt HelloBucket.Arn
+                  - !Sub "arn:aws:s3:::${CollaborationBucketName}"
+                  - !Sub "arn:aws:s3:::${CollaborationBucketName}/*"
 
   HelloWorldLambda:
     Type: AWS::Lambda::Function

--- a/stack/app-stack.yaml
+++ b/stack/app-stack.yaml
@@ -80,9 +80,11 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - logs:CreateLogEvents
+                  - s3:PutObject
                 Resource:
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${ProjectName}-${UniqueEnvName}-${AWS::Region}-lambda"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${ProjectName}-${UniqueEnvName}-${AWS::Region}-lambda:*"
+                  - !GetAtt HelloBucket.Arn
 
   HelloWorldLambda:
     Type: AWS::Lambda::Function

--- a/stack/src/presign.py
+++ b/stack/src/presign.py
@@ -6,7 +6,9 @@ from botocore.exceptions import ClientError
 
 
 def handler(event, context):
-    if "queryStringParameters" in event:
+    params = event["queryStringParameters"]
+    if "action" in params:
+        # Prototype multi-part upload
         action = event["queryStringParameters"]["action"]
         if action.lower() == "start":
             return {
@@ -23,15 +25,15 @@ def handler(event, context):
                 'statusCode': 400,
                 'body': 'uh-oh'
             }
-
-
-    object_name = os.path.basename(event["params"]["querystring"]["file"])
-    bucket_name = os.environ["BUCKET"]
-    response = presigned_post(bucket_name, object_name)
-    return {
-        'statusCode': 200,
-        'body': json.dumps(response)
-    }
+    else:
+        # Pre-sign URL
+        object_name = os.path.basename(params["file"])
+        bucket_name = os.environ["BUCKET"]
+        response = presigned_post(bucket_name, object_name)
+        return {
+            'statusCode': 200,
+            'body': json.dumps(response)
+        }
 
 
 def presigned_post(


### PR DESCRIPTION
Fixed Lambda S3 permissions to allow `forest-upload` tool to send data to a private bucket.
- The lambda REST endpoint has been converted to `aws_proxy`
- A `-version` flag was added to the `forest-upload` tool to let users know which build they are running