### PR TITLE
Datashader support

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -20,6 +20,8 @@ forecasts alongside observations.
 
 .. automodule:: forest.load
 
+.. automodule:: forest.geo
+
 """
 __version__ = '0.4.4'
 

--- a/forest/geo.py
+++ b/forest/geo.py
@@ -45,9 +45,10 @@ def stretch_image(lons, lats, values):
     _, gy = web_mercator(
         np.zeros(len(lats), dtype="d"),
         lats)
-
+    x_range = (gx.min(), gx.max())
+    y_range = (gy.min(), gy.max())
     if datashader:
-        image = datashader_stretch(values, gx, gy)
+        image = datashader_stretch(values, gx, gy, x_range, y_range)
     else:
         image = custom_stretch()
     x = gx.min()
@@ -81,8 +82,10 @@ def datashader_stretch(values, gx, gy, x_range, y_range):
                                y_range=y_range)
     xarr = xarray.DataArray(values, coords=[('x', gx), ('y', gy)], name='Z')
     image = canvas.quadmesh(xarr)
-    return image
 
+    return np.ma.masked_array(image.values,
+                          mask=np.isnan(
+                              image.values))
 
 def custom_stretch(values, gx, gy):
     if np.ma.is_masked(values):

--- a/forest/geo.py
+++ b/forest/geo.py
@@ -45,12 +45,12 @@ def stretch_image(lons, lats, values):
     _, gy = web_mercator(
         np.zeros(len(lats), dtype="d"),
         lats)
-    x_range = (gx.min(), gx.max())
-    y_range = (gy.min(), gy.max())
     if datashader:
+        x_range = (gx.min(), gx.max())
+        y_range = (gy.min(), gy.max())
         image = datashader_stretch(values, gx, gy, x_range, y_range)
     else:
-        image = custom_stretch()
+        image = custom_stretch(values, gx, gy)
     x = gx.min()
     y = gy.min()
     dw = gx[-1] - gx[0]
@@ -80,9 +80,8 @@ def datashader_stretch(values, gx, gy, x_range, y_range):
                                plot_width=values.shape[1],
                                x_range=x_range,
                                y_range=y_range)
-    xarr = xarray.DataArray(values, coords=[('x', gx), ('y', gy)], name='Z')
+    xarr = xarray.DataArray(values, coords=[('y', gy), ('x', gx)], name='Z')
     image = canvas.quadmesh(xarr)
-
     return np.ma.masked_array(image.values,
                           mask=np.isnan(
                               image.values))

--- a/forest/geo.py
+++ b/forest/geo.py
@@ -37,6 +37,19 @@ def stretch_image(lons, lats, values):
         "image": [image]
     }
 
+def bokeh_image(lat, lon, data):
+    x= []
+    y = []
+    dh = []
+    dw = []
+    image = []
+    return {
+        "x": x,
+        "y": y,
+        "dw": dw,
+        "dh": dh,
+        "image": image
+    }
 
 def stretch_y(uneven_y):
     """Mercator projection stretches longitude spacing

--- a/forest/geo.py
+++ b/forest/geo.py
@@ -24,7 +24,7 @@ def stretch_image(lons, lats, values):
         lats)
 
     if datashader:
-        image = datashder_stretch()
+        image = datashader_stretch(values, gx, gy)
     else:
         image = custom_stretch()
     x = gx.min()
@@ -39,12 +39,24 @@ def stretch_image(lons, lats, values):
         "image": [image]
     }
 
+
 def datashader_stretch(values, gx, gy, x_range, y_range):
+    """
+    Use datashader to sample the data mesh in on a regular grid for use in
+    image display.
+
+    :param values: A numpy array of image data
+    :param gx: The array of coordinates in projection space.
+    :param gy: The array of coordinates in projection space.
+    :param x_range: The range of the mesh in projection space.
+    :param y_range: The range of the mesh in projection space.
+    :return: An xarray of image data representing pixels.
+    """
     canvas = datashader.Canvas(plot_height=values.shape[0],
                                plot_width=values.shape[1],
                                x_range=x_range,
                                y_range=y_range)
-    xarr = xarray.DataArray(values,coords=[('x',gx),('y',gy)],name='Z')
+    xarr = xarray.DataArray(values, coords=[('x', gx), ('y', gy)], name='Z')
     image = canvas.quadmesh(xarr)
     return image
 
@@ -57,30 +69,10 @@ def custom_stretch(values, gx, gy):
     image = stretch_y(gy)(values)
     if mask is not None:
         image_mask = stretch_y(gy)(mask)
-        image = np.ma.masked_invalid(np.ma.masked_array(image, mask=image_mask))
+        image = np.ma.masked_invalid(
+            np.ma.masked_array(image, mask=image_mask))
     return image
 
-
-def bokeh_image(lat, lon, data):
-    x= []
-    y = []
-    dh = []
-    dw = []
-    x_range = 0
-    y_range = 0
-    image = []
-    # canvas = ds.Canvas( )
-    # rasterised_array = canvas.raster()
-    return {
-        "x": x,
-        "y": y,
-        "dw": dw,
-        "dh": dh,
-        "image": image
-    }
-
-def raster_data(x, y, data):
-    pass
 
 def stretch_y(uneven_y):
     """Mercator projection stretches longitude spacing

--- a/forest/geo.py
+++ b/forest/geo.py
@@ -1,4 +1,7 @@
 """
+Geographic utilities module
+---------------------------
+
 Module to handle projection and sampling iof points for imaging.
 
 .. autofunction:: stretch_image

--- a/forest/geo.py
+++ b/forest/geo.py
@@ -6,6 +6,10 @@ Module to handle projection and sampling iof points for imaging.
 
 .. autofunction:: stretch_image
 
+.. autofunction:: web_mercator
+
+.. autofunction:: plate_carree
+
 """
 try:
     import cartopy

--- a/forest/geo.py
+++ b/forest/geo.py
@@ -1,3 +1,9 @@
+"""
+Module to handle projection and sampling iof points for imaging.
+
+.. autofunction:: stretch_image
+
+"""
 try:
     import cartopy
 except ImportError:
@@ -16,6 +22,16 @@ except ModuleNotFoundError:
     datashader = None
 
 def stretch_image(lons, lats, values):
+    """
+    Do the mapping from image data to the format required by bokeh
+    for plotting.
+
+    :param lons: Numpy array with latitude values for the image data.
+    :param lats: Numpy array with longitude values for the image data.
+    :param values: Numpy array of image data, with dimensions matching the
+                   size of latitude and longitude arrays.
+    :return: A dictionary that can be used with the bokeh image glyph.
+    """
     gx, _ = web_mercator(
         lons,
         np.zeros(len(lons), dtype="d"))

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -1,0 +1,10 @@
+from forest import geo
+import pytest
+
+@pytest.mark.parametrize(
+'lon,lat,data,expected',
+    [([],[],[],{'x':[],'y':[],'dh':[],'dw':[],'image':[]}),
+])
+def test_ds_pipeline(lon, lat, data, expected):
+    output = geo.bokeh_image(lon, lat, data)
+    assert output == expected

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -1,46 +1,8 @@
-import datashader
 import numpy
 import pytest
 import xarray
 
 from forest import geo
-
-def f(x,y):
-    return numpy.cos((x**2+y**2)**2)
-
-def sample(fn, n, range):
-    xs = ys = numpy.linspace(range_[0], range_[1], n)
-    x,y = numpy.meshgrid(xs, ys)
-    z   = fn(x,y)
-    return xarray.DataArray(z, coords=[('y',ys), ('x',xs)])
-
-
-@pytest.mark.parametrize(
-'x,y,data,expected',
-    [([],[],[],{'x':[],'y':[],'dh':[],'dw':[],'image':[]}),
-])
-def test_ds_pipeline(x, y, data, expected):
-    output = geo.bokeh_image(x, y, data)
-    assert output == expected
-
-
-def test_raster_identity():
-    test_vals =  xarray.DataArray([[5,2],[3,4]],coords=[('x',[0.0,1.0]),('y',[0.0,1.0])],name='Z')
-    test_canvas = datashader.Canvas(plot_height=2, plot_width=2, x_range=(0.0, 1.0),
-                                    y_range=(0.0, 1.0))
-    output_arr = test_canvas.quadmesh(test_vals)
-    assert output_arr.shape == (2,2)
-    numpy.testing.assert_array_equal(output_arr, test_vals)
-
-def test_raster_data():
-    test_vals =  xarray.DataArray([[5,2],[3,4]],coords=[('x',[0.1,0.9]),('y',[0.1,0.9])])
-    test_canvas = datashader.Canvas(plot_height=5, plot_width=5, x_range=(0.0, 1.0),
-                                    y_range=(0.0, 1.0))
-    output_arr = test_canvas.raster(test_vals, interpolate='nearest')
-    assert output_arr.shape == (5,5)
-    ref_arr =  xarray.DataArray([[5,5,5,2,2],[5,5,5,2,2],[5,5,5,2,2],[3,3,3,4,4],[3,3,3,4,4]],coords=[('x',[0.1,0.3, 0.5, 0.7, 0.9]),('y',[0.1,0.3, 0.5, 0.7, 0.9])])
-    numpy.testing.assert_array_equal(output_arr, ref_arr)
-
 
 def test_datashder_stretch():
     gx = numpy.array([0.25, 0.75])
@@ -50,5 +12,6 @@ def test_datashder_stretch():
     values = numpy.array([[0.0, 1.0], [2.0, 3.0]])
     output_image = geo.datashader_stretch(values, gx, gy, x_range, y_range)
     reference_image = xarray.DataArray(values,
-                                       coords=[('x', [0.25, 0.75]), ('y', [0.25, 0.75])])
+                                       coords=[('x', [0.25, 0.75]),
+                                               ('y', [0.25, 0.75])])
     xarray.testing.assert_equal(output_image, reference_image)

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -7,14 +7,13 @@ from forest import geo
 try:
     import datashader
     import xarray
-    datashader_available = True
+    libs_available = True
 except ModuleNotFoundError:
-    datashader_available = False
+    libs_available = False
 
 
-@pytest.mark.skipif(not datashader_available,
-                    reason='Test skipped if optional library datashader and '
-                           'xarray not present.')
+@pytest.mark.skipif(not libs_available,
+                    reason='datashader and xarray are optional')
 def test_datashder_stretch():
     gx = numpy.array([0.25, 0.75])
     gy = numpy.array([0.25, 0.75])
@@ -36,6 +35,8 @@ def test_custom_stretch():
     numpy.testing.assert_array_equal(geo.custom_stretch(z, x, y), z)
 
 
+@pytest.mark.skipif(not libs_available,
+                    reason='datashader and xarray are optional')
 def test_datashader_stretch_image():
     x = numpy.array([0, 1])
     y = numpy.array([0, 1, 2])

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -27,3 +27,21 @@ def test_datashder_stretch():
                                                ('y', [0.25, 0.75])])
     assert isinstance(output_image, numpy.ndarray)
     numpy.testing.assert_array_equal(output_image, reference_image)
+
+
+def test_custom_stretch():
+    x = numpy.array([0, 1])
+    y = numpy.array([0, 1, 2])
+    z = numpy.array([[0, 1], [2, 3], [4, 5]])
+    numpy.testing.assert_array_equal(geo.custom_stretch(z, x, y), z)
+
+
+def test_datashader_stretch_image():
+    x = numpy.array([0, 1])
+    y = numpy.array([0, 1, 2])
+    z = numpy.array([[0, 1], [2, 3], [4, 5]])
+    x_range = (-0.5, 1.5)
+    y_range = (-0.5, 2.5)
+    result = geo.datashader_stretch(z, x, y, x_range, y_range)
+    expect = z
+    numpy.testing.assert_array_equal(result, expect)

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -2,9 +2,9 @@ from forest import geo
 import pytest
 
 @pytest.mark.parametrize(
-'lon,lat,data,expected',
+'x,y,data,expected',
     [([],[],[],{'x':[],'y':[],'dh':[],'dw':[],'image':[]}),
 ])
-def test_ds_pipeline(lon, lat, data, expected):
-    output = geo.bokeh_image(lon, lat, data)
+def test_ds_pipeline(x, y, data, expected):
+    output = geo.bokeh_image(x, y, data)
     assert output == expected

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -14,4 +14,5 @@ def test_datashder_stretch():
     reference_image = xarray.DataArray(values,
                                        coords=[('x', [0.25, 0.75]),
                                                ('y', [0.25, 0.75])])
-    xarray.testing.assert_equal(output_image, reference_image)
+    assert isinstance(output_image, numpy.ndarray)
+    numpy.testing.assert_array_equal(output_image, reference_image)

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -4,6 +4,17 @@ import xarray
 
 from forest import geo
 
+try:
+    import datashader
+    import xarray
+    datashader_available = True
+except ModuleNotFoundError:
+    datashader_available = False
+
+
+@pytest.mark.skipif(not datashader_available,
+                    reason='Test skipped if optional library datashader and '
+                           'xarray not present.')
 def test_datashder_stretch():
     gx = numpy.array([0.25, 0.75])
     gy = numpy.array([0.25, 0.75])

--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -1,5 +1,19 @@
-from forest import geo
+import datashader
+import numpy
 import pytest
+import xarray
+
+from forest import geo
+
+def f(x,y):
+    return numpy.cos((x**2+y**2)**2)
+
+def sample(fn, n, range):
+    xs = ys = numpy.linspace(range_[0], range_[1], n)
+    x,y = numpy.meshgrid(xs, ys)
+    z   = fn(x,y)
+    return xarray.DataArray(z, coords=[('y',ys), ('x',xs)])
+
 
 @pytest.mark.parametrize(
 'x,y,data,expected',
@@ -8,3 +22,33 @@ import pytest
 def test_ds_pipeline(x, y, data, expected):
     output = geo.bokeh_image(x, y, data)
     assert output == expected
+
+
+def test_raster_identity():
+    test_vals =  xarray.DataArray([[5,2],[3,4]],coords=[('x',[0.0,1.0]),('y',[0.0,1.0])],name='Z')
+    test_canvas = datashader.Canvas(plot_height=2, plot_width=2, x_range=(0.0, 1.0),
+                                    y_range=(0.0, 1.0))
+    output_arr = test_canvas.quadmesh(test_vals)
+    assert output_arr.shape == (2,2)
+    numpy.testing.assert_array_equal(output_arr, test_vals)
+
+def test_raster_data():
+    test_vals =  xarray.DataArray([[5,2],[3,4]],coords=[('x',[0.1,0.9]),('y',[0.1,0.9])])
+    test_canvas = datashader.Canvas(plot_height=5, plot_width=5, x_range=(0.0, 1.0),
+                                    y_range=(0.0, 1.0))
+    output_arr = test_canvas.raster(test_vals, interpolate='nearest')
+    assert output_arr.shape == (5,5)
+    ref_arr =  xarray.DataArray([[5,5,5,2,2],[5,5,5,2,2],[5,5,5,2,2],[3,3,3,4,4],[3,3,3,4,4]],coords=[('x',[0.1,0.3, 0.5, 0.7, 0.9]),('y',[0.1,0.3, 0.5, 0.7, 0.9])])
+    numpy.testing.assert_array_equal(output_arr, ref_arr)
+
+
+def test_datashder_stretch():
+    gx = numpy.array([0.25, 0.75])
+    gy = numpy.array([0.25, 0.75])
+    x_range = numpy.array([0.0, 1.0])
+    y_range = numpy.array([0.0, 1.0])
+    values = numpy.array([[0.0, 1.0], [2.0, 3.0]])
+    output_image = geo.datashader_stretch(values, gx, gy, x_range, y_range)
+    reference_image = xarray.DataArray(values,
+                                       coords=[('x', [0.25, 0.75]), ('y', [0.25, 0.75])])
+    xarray.testing.assert_equal(output_image, reference_image)


### PR DESCRIPTION
This PR implements a basic proof of concept of using datashader as the remapping step in FOREST instead of te custom stretch function. Building on this work we will be able to make use of more sophisticated datashader functionality for upscaling, downscaling and plotting of irregular datasets.