### PR TITLE
Colorbar preset

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -22,6 +22,8 @@ forecasts alongside observations.
 
 .. automodule:: forest.geo
 
+.. automodule:: forest.presets
+
 """
 __version__ = '0.4.4'
 

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -339,24 +339,33 @@ class UserLimits(Observable):
         }
         self.inputs["low"].on_change("value", self.on_input_low)
         self.inputs["high"].on_change("value", self.on_input_high)
-        self.checkbox = bokeh.models.CheckboxGroup(
+
+        self.checkboxes = {}
+
+        # Checkbox fix data limits to user supplied limits
+        self.checkboxes["fixed"] = bokeh.models.CheckboxGroup(
                 labels=["Fix min/max settings for all frames"],
                 active=[])
-        self.checkbox.on_change("active", self.on_checkbox_change)
-        self.checkbox_invisible_min = bokeh.models.CheckboxGroup(
+        self.checkboxes["fixed"].on_change("active", self.on_checkbox_change)
+
+        # Checkbox transparency lower threshold
+        self.checkboxes["invisible_min"] = bokeh.models.CheckboxGroup(
             labels=["Set data below Min to transparent"],
             active=[])
-        self.checkbox_invisible_min.on_change("active", self.on_invisible_min)
-        self.checkbox_invisible_max = bokeh.models.CheckboxGroup(
+        self.checkboxes["invisible_min"].on_change("active", self.on_invisible_min)
+
+        # Checkbox transparency upper threshold
+        self.checkboxes["invisible_max"] = bokeh.models.CheckboxGroup(
             labels=["Set data above Max to transparent"],
             active=[])
-        self.checkbox_invisible_max.on_change("active", self.on_invisible_max)
+        self.checkboxes["invisible_max"].on_change("active", self.on_invisible_max)
+
         self.layout = bokeh.layouts.column(
             self.inputs["low"],
             self.inputs["high"],
-            self.checkbox,
-            self.checkbox_invisible_min,
-            self.checkbox_invisible_max,
+            self.checkboxes["fixed"],
+            self.checkboxes["invisible_min"],
+            self.checkboxes["invisible_max"],
         )
         super().__init__()
 
@@ -391,10 +400,12 @@ class UserLimits(Observable):
 
     def render(self, props):
         """Update user-defined limits inputs"""
-        if props.get("fixed", False):
-            self.checkbox.active = [0]
-        else:
-            self.checkbox.active = []
+        for key in ["fixed", "invisible_min", "invisible_max"]:
+            if props.get(key, False):
+                self.checkboxes[key].active = [0]
+            else:
+                self.checkboxes[key].active = []
+
         if "high" in props:
             self.inputs["high"].value = str(props["high"])
         if "low" in props:

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -391,6 +391,10 @@ class UserLimits(Observable):
 
     def render(self, props):
         """Update user-defined limits inputs"""
+        if props.get("fixed", False):
+            self.checkbox.active = [0]
+        else:
+            self.checkbox.active = []
         if "high" in props:
             self.inputs["high"].value = str(props["high"])
         if "low" in props:

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -521,6 +521,12 @@ class ColorPalette(Observable):
         else:
             self.color_mapper.high_color = None
 
+        # Render reverse checkbox state
+        if props.get("reverse", False):
+            self.checkbox.active = [0]
+        else:
+            self.checkbox.active = []
+
     @staticmethod
     def palette(name, number):
         return bokeh.palettes.all_palettes[name][number]

--- a/forest/main.py
+++ b/forest/main.py
@@ -19,6 +19,7 @@ from forest import (
         colors,
         db,
         keys,
+        presets,
         redux,
         rx,
         unified_model,
@@ -270,13 +271,15 @@ def main(argv=None):
             "valid_times": db.stamps,
             "inital_times": db.stamps
         }),
-        colors.palettes
+        colors.palettes,
+        presets.middleware
     ]
     store = redux.Store(
         redux.combine_reducers(
             db.reducer,
             series.reducer,
-            colors.reducer),
+            colors.reducer,
+            presets.reducer),
         initial_state=initial_state,
         middlewares=middlewares)
 
@@ -288,6 +291,9 @@ def main(argv=None):
     source_limits.subscribe(store.dispatch)
 
     user_limits = colors.UserLimits().connect(store)
+
+    # Preset
+    preset_ui = presets.PresetUI().connect(store)
 
     # Connect navigation controls
     controls = db.ControlView()
@@ -321,6 +327,7 @@ def main(argv=None):
             child=bokeh.layouts.column(
                 border_row,
                 bokeh.layouts.row(slider),
+                preset_ui.layout,
                 color_palette.layout,
                 user_limits.layout
                 ),

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -22,9 +22,9 @@ from forest.observe import Observable
 from forest import redux, rx
 
 # Action kinds
-SAVE_PRESET = "SAVE_PRESET"
-LOAD_PRESET = "LOAD_PRESET"
-REMOVE_PRESET = "REMOVE_PRESET"
+PRESET_SAVE = "PRESET_SAVE"
+PRESET_LOAD = "PRESET_LOAD"
+PRESET_REMOVE = "PRESET_REMOVE"
 PRESET_SET_META = "PRESET_SET_META"
 PRESET_ON_SAVE = "PRESET_ON_SAVE"
 PRESET_ON_NEW = "PRESET_ON_NEW"
@@ -38,17 +38,17 @@ EDIT = "EDIT"
 
 def save_preset(label):
     """Action to save a preset"""
-    return {"kind": SAVE_PRESET, "payload": label}
+    return {"kind": PRESET_SAVE, "payload": label}
 
 
 def load_preset(label):
     """Action to load a preset by label"""
-    return {"kind": LOAD_PRESET, "payload": label}
+    return {"kind": PRESET_LOAD, "payload": label}
 
 
 def remove_preset():
     """Action to remove a preset"""
-    return {"kind": REMOVE_PRESET}
+    return {"kind": PRESET_REMOVE}
 
 
 def set_default_mode():
@@ -104,7 +104,7 @@ def middleware(store, action):
 def reducer(state, action):
     state = copy.deepcopy(state)
     kind = action["kind"]
-    if kind == SAVE_PRESET:
+    if kind == PRESET_SAVE:
         label = action["payload"]
         try:
             uid = Query(state).find_id(label)
@@ -123,14 +123,14 @@ def reducer(state, action):
             settings = {}
         state["presets"]["settings"][uid] = settings
 
-    elif kind == LOAD_PRESET:
+    elif kind == PRESET_LOAD:
         label = action["payload"]
         uid = Query(state).find_id(label)
         settings = copy.deepcopy(state["presets"]["settings"][uid])
         print(label, uid, settings)
         state["colorbar"] = settings
         state["presets"]["active"] = uid
-    elif kind == REMOVE_PRESET:
+    elif kind == PRESET_REMOVE:
         uid = state["presets"]["active"]
         del state["presets"]["labels"][uid]
         del state["presets"]["active"]

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -4,15 +4,53 @@ Presets
 
 User configured settings can be saved, edited and deleted.
 
+UI components
+~~~~~~~~~~~~~
 
 .. autoclass:: PresetUI
    :members:
 
+Reducer
+~~~~~~~
+
 .. autofunction:: reducer
+
+Middleware
+~~~~~~~~~~
+
+Middleware pre-processes actions prior to the reducer
+
+.. autofunction:: middleware
+
+Helpers
+~~~~~~~
+
+.. autofunction:: state_to_props
+
+Actions
+~~~~~~~
+
+A simple grammar used to communicate between components.
 
 .. autofunction:: save_preset
 
 .. autofunction:: load_preset
+
+.. autofunction:: remove_preset
+
+.. autofunction:: set_default_mode
+
+.. autofunction:: set_edit_mode
+
+.. autofunction:: set_edit_label
+
+.. autofunction:: on_save
+
+.. autofunction:: on_edit
+
+.. autofunction:: on_new
+
+.. autofunction:: on_cancel
 
 """
 import copy
@@ -52,39 +90,53 @@ def remove_preset():
 
 
 def set_default_mode():
+    """Action to select default display mode"""
     return {"kind": PRESET_SET_META, "meta": {"mode": DEFAULT}}
 
 
 def set_edit_mode():
+    """Action to select edit display mode"""
     return {"kind": PRESET_SET_META, "meta": {"mode": EDIT}}
 
 
 def set_edit_label(label):
+    """Action to set edit mode label"""
     return {"kind": PRESET_SET_META, "meta": {"label": label}}
 
 
 def on_save(label):
+    """Action to signal save clicked"""
     return {"kind": PRESET_ON_SAVE, "payload": label}
 
 
 def on_edit():
+    """Action to signal edit clicked"""
     return {"kind": PRESET_ON_EDIT}
 
 
 def on_new():
+    """Action to signal new clicked"""
     return {"kind": PRESET_ON_NEW}
 
 
 def on_cancel():
+    """Action to signal cancel clicked"""
     return {"kind": PRESET_ON_CANCEL}
 
 
 def state_to_props(state):
+    """Converts application state to props used by user interface"""
     query = Query(state)
     return query.labels, query.display_mode, query.edit_label
 
 
 def middleware(store, action):
+    """Presets middleware
+
+    Generates actions given current state and an incoming action. Encapsulates
+    the business logic surrounding saving, editing and creating presets.
+
+    """
     kind = action["kind"]
     if kind == PRESET_ON_SAVE:
         yield save_preset(action["payload"])
@@ -102,6 +154,10 @@ def middleware(store, action):
 
 
 def reducer(state, action):
+    """Presets reducer
+
+    :returns: next state
+    """
     state = copy.deepcopy(state)
     kind = action["kind"]
     if kind == PRESET_SAVE:
@@ -193,7 +249,11 @@ def new_id(ids):
 
 
 class PresetUI(Observable):
-    """User interface to load/save/edit presets"""
+    """User interface to load/save/edit presets
+
+    >>> preset_ui = PresetUI().connect(store)
+
+    """
     def __init__(self):
         self.select = bokeh.models.Select()
         self.select.on_change("value", self.on_load)

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -77,16 +77,15 @@ def state_to_props(state):
     return options, mode
 
 
-@redux.middleware
-def middleware(store, next_dispatch, action):
+def middleware(store, action):
     kind = action["kind"]
     if kind == PRESET_ON_SAVE:
-        next_dispatch(save_preset(action["payload"]))
-        next_dispatch(set_default_mode())
+        yield save_preset(action["payload"])
+        yield set_default_mode()
     elif kind == PRESET_ON_CANCEL:
-        next_dispatch(set_default_mode())
+        yield set_default_mode()
     else:
-        next_dispatch(action)
+        yield action
 
 
 def reducer(state, action):

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -187,6 +187,7 @@ class PresetUI(Observable):
     """User interface to load/save/edit presets"""
     def __init__(self):
         self.select = bokeh.models.Select()
+        self.select.on_change("value", self.on_load)
         self.text_input = bokeh.models.TextInput(placeholder="Save name")
         self.buttons = {
             "edit": bokeh.models.Button(label="Edit"),
@@ -236,10 +237,9 @@ class PresetUI(Observable):
         if label != "":
             self.notify(on_save(label))
 
-    def on_load(self):
+    def on_load(self, attr, old, new):
         """Notify listeners that a load action has taken place"""
-        label = self.select.value
-        self.notify(load_preset(label))
+        self.notify(load_preset(new))
 
     def on_new(self):
         self.notify(on_new())

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -1,0 +1,229 @@
+"""
+Presets
+-------
+
+User configured settings can be saved, edited and deleted.
+
+
+.. autoclass:: PresetUI
+   :members:
+
+.. autofunction:: reducer
+
+.. autofunction:: save_preset
+
+.. autofunction:: load_preset
+
+"""
+import copy
+import bokeh.models
+import bokeh.layouts
+from forest.observe import Observable
+from forest import redux, rx
+
+# Action kinds
+SAVE_PRESET = "SAVE_PRESET"
+LOAD_PRESET = "LOAD_PRESET"
+RENAME_PRESET = "RENAME_PRESET"
+REMOVE_PRESET = "REMOVE_PRESET"
+PRESET_SET_META = "PRESET_SET_META"
+PRESET_ON_SAVE = "PRESET_ON_SAVE"
+PRESET_ON_CANCEL = "PRESET_ON_CANCEL"
+
+# Display modes
+DEFAULT = "DEFAULT"
+EDIT = "EDIT"
+
+
+def save_preset(label):
+    """Action to save a preset"""
+    return {"kind": SAVE_PRESET, "payload": label}
+
+
+def load_preset(label):
+    """Action to load a preset by label"""
+    return {"kind": LOAD_PRESET, "payload": label}
+
+
+def rename_preset(label):
+    """Action to rename a preset"""
+    return {"kind": RENAME_PRESET, "payload": label}
+
+
+def remove_preset():
+    """Action to remove a preset"""
+    return {"kind": REMOVE_PRESET}
+
+
+def set_default_mode():
+    return {"kind": PRESET_SET_META, "meta": {"mode": DEFAULT}}
+
+
+def set_edit_mode():
+    return {"kind": PRESET_SET_META, "meta": {"mode": EDIT}}
+
+
+def on_save(label):
+    return {"kind": PRESET_ON_SAVE, "payload": label}
+
+
+def on_cancel():
+    return {"kind": PRESET_ON_CANCEL}
+
+
+def state_to_props(state):
+    options = list(state.get("presets", {}).get("labels", {}).values())
+    mode = state.get("presets", {}).get("meta", {}).get("mode", DEFAULT)
+    return options, mode
+
+
+@redux.middleware
+def middleware(store, next_dispatch, action):
+    kind = action["kind"]
+    if kind == PRESET_ON_SAVE:
+        next_dispatch(save_preset(action["payload"]))
+        next_dispatch(set_default_mode())
+    elif kind == PRESET_ON_CANCEL:
+        next_dispatch(set_default_mode())
+    else:
+        next_dispatch(action)
+
+
+def reducer(state, action):
+    state = copy.deepcopy(state)
+    kind = action["kind"]
+    if kind == SAVE_PRESET:
+        label = action["payload"]
+        try:
+            uid = find_id(state, label)
+        except IDNotFound:
+            uid = new_id(all_ids(state))
+        if "presets" not in state:
+            state["presets"] = {}
+        if "labels" not in state["presets"]:
+            state["presets"]["labels"] = {}
+        if "settings" not in state["presets"]:
+            state["presets"]["settings"] = {}
+        state["presets"]["labels"][uid] = label
+        if "colorbar" in state:
+            settings = copy.deepcopy(state["colorbar"])
+        else:
+            settings = {}
+        state["presets"]["settings"][uid] = settings
+
+    elif kind == LOAD_PRESET:
+        label = action["payload"]
+        uid = find_id(state, label)
+        settings = copy.deepcopy(state["presets"]["settings"][uid])
+        print(label, uid, settings)
+        state["colorbar"] = settings
+        state["presets"]["active"] = uid
+    elif kind == RENAME_PRESET:
+        uid = state["presets"]["active"]
+        state["presets"]["labels"][uid] = action["payload"]
+    elif kind == REMOVE_PRESET:
+        uid = state["presets"]["active"]
+        del state["presets"]["labels"][uid]
+        del state["presets"]["active"]
+    elif kind == PRESET_SET_META:
+        if "presets" not in state:
+            state["presets"] = {}
+        if "meta" not in state["presets"]:
+            state["presets"]["meta"] = {}
+        state["presets"]["meta"].update(action["meta"])
+    return state
+
+
+class IDNotFound(Exception):
+    pass
+
+
+def find_id(state, label):
+    labels = state.get("presets", {}).get("labels", {})
+    for id, _label in labels.items():
+        if _label == label:
+            return id
+    raise IDNotFound("'{}' not found".format(label))
+
+
+def all_ids(state):
+    return set(state.get("presets", {}).get("labels", {}).keys())
+
+
+def new_id(ids):
+    if len(ids) == 0:
+        return 0
+    return max(ids) + 1
+
+
+class PresetUI(Observable):
+    """User interface to load/save/edit presets"""
+    def __init__(self):
+        self.select = bokeh.models.Select()
+        self.text_input = bokeh.models.TextInput(placeholder="Save name")
+        self.buttons = {
+            "edit": bokeh.models.Button(label="Edit"),
+            "new": bokeh.models.Button(label="New"),
+            "cancel": bokeh.models.Button(label="Cancel"),
+            "save": bokeh.models.Button(label="Save"),
+        }
+        self.buttons["save"].on_click(self.on_save)
+        self.buttons["new"].on_click(self.on_new)
+        self.buttons["edit"].on_click(self.on_edit)
+        self.buttons["cancel"].on_click(self.on_cancel)
+        width = 320
+        self.children = {
+            DEFAULT: [
+                self.select, self.buttons["edit"], self.buttons["new"]
+            ],
+            EDIT: [
+                self.text_input, self.buttons["cancel"], self.buttons["save"]
+            ]
+        }
+        self.rows = {
+                "title": bokeh.layouts.row(
+                    bokeh.models.Div(text="Presets:"),
+                    width=width),
+                "content": bokeh.layouts.row(
+                    self.children[DEFAULT],
+                    width=width)}
+        self.layout = bokeh.layouts.column(
+                self.rows["title"],
+                self.rows["content"])
+        super().__init__()
+
+    def connect(self, store):
+        """Convenient method to map state to props needed by render"""
+        self.subscribe(store.dispatch)
+        stream = (rx.Stream()
+                    .listen_to(store)
+                    .map(state_to_props)
+                    .filter(lambda x: x is not None)
+                    .distinct())
+        stream.map(lambda props: self.render(*props))
+        return self
+
+    def on_save(self):
+        """Notify listeners that a save action has taken place"""
+        label = self.text_input.value
+        if label != "":
+            self.notify(on_save(label))
+
+    def on_load(self):
+        """Notify listeners that a load action has taken place"""
+        label = self.select.value
+        self.notify(load_preset(label))
+
+    def on_new(self):
+        self.notify(set_edit_mode())
+
+    def on_edit(self):
+        self.notify(set_edit_mode())
+
+    def on_cancel(self):
+        self.notify(on_cancel())
+
+    def render(self, labels, mode):
+        # TODO: Add support for DEFAULT/EDIT mode layouts
+        self.rows["content"].children = self.children[mode]
+        self.select.options = list(sorted(labels))

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -28,6 +28,8 @@ RENAME_PRESET = "RENAME_PRESET"
 REMOVE_PRESET = "REMOVE_PRESET"
 PRESET_SET_META = "PRESET_SET_META"
 PRESET_ON_SAVE = "PRESET_ON_SAVE"
+PRESET_ON_NEW = "PRESET_ON_NEW"
+PRESET_ON_EDIT = "PRESET_ON_EDIT"
 PRESET_ON_CANCEL = "PRESET_ON_CANCEL"
 
 # Display modes
@@ -67,6 +69,14 @@ def on_save(label):
     return {"kind": PRESET_ON_SAVE, "payload": label}
 
 
+def on_edit():
+    return {"kind": PRESET_ON_EDIT}
+
+
+def on_new():
+    return {"kind": PRESET_ON_NEW}
+
+
 def on_cancel():
     return {"kind": PRESET_ON_CANCEL}
 
@@ -84,6 +94,10 @@ def middleware(store, action):
         yield set_default_mode()
     elif kind == PRESET_ON_CANCEL:
         yield set_default_mode()
+    elif kind == PRESET_ON_EDIT:
+        yield set_edit_mode()
+    elif kind == PRESET_ON_NEW:
+        yield set_edit_mode()
     else:
         yield action
 
@@ -214,10 +228,10 @@ class PresetUI(Observable):
         self.notify(load_preset(label))
 
     def on_new(self):
-        self.notify(set_edit_mode())
+        self.notify(on_new())
 
     def on_edit(self):
-        self.notify(set_edit_mode())
+        self.notify(on_edit())
 
     def on_cancel(self):
         self.notify(on_cancel())

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -24,7 +24,6 @@ from forest import redux, rx
 # Action kinds
 SAVE_PRESET = "SAVE_PRESET"
 LOAD_PRESET = "LOAD_PRESET"
-RENAME_PRESET = "RENAME_PRESET"
 REMOVE_PRESET = "REMOVE_PRESET"
 PRESET_SET_META = "PRESET_SET_META"
 PRESET_ON_SAVE = "PRESET_ON_SAVE"
@@ -45,11 +44,6 @@ def save_preset(label):
 def load_preset(label):
     """Action to load a preset by label"""
     return {"kind": LOAD_PRESET, "payload": label}
-
-
-def rename_preset(label):
-    """Action to rename a preset"""
-    return {"kind": RENAME_PRESET, "payload": label}
 
 
 def remove_preset():
@@ -131,9 +125,6 @@ def reducer(state, action):
         print(label, uid, settings)
         state["colorbar"] = settings
         state["presets"]["active"] = uid
-    elif kind == RENAME_PRESET:
-        uid = state["presets"]["active"]
-        state["presets"]["labels"][uid] = action["payload"]
     elif kind == REMOVE_PRESET:
         uid = state["presets"]["active"]
         del state["presets"]["labels"][uid]

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -183,6 +183,23 @@ def test_controls_render_palette(props, palette):
     assert color_mapper.palette == palette
 
 
+@pytest.mark.parametrize("key,props,active", [
+    ("fixed", {}, []),
+    ("fixed", {"fixed": False}, []),
+    ("fixed", {"fixed": True}, [0]),
+    ("invisible_min", {}, []),
+    ("invisible_min", {"invisible_min": False}, []),
+    ("invisible_min", {"invisible_min": True}, [0]),
+    ("invisible_max", {}, []),
+    ("invisible_max", {"invisible_max": False}, []),
+    ("invisible_max", {"invisible_max": True}, [0]),
+])
+def test_controls_render_checkboxes(key, props, active):
+    user_limits = colors.UserLimits()
+    user_limits.render(props)
+    assert user_limits.checkboxes[key].active == active
+
+
 def test_user_limits_render():
     user_limits = colors.UserLimits()
     user_limits.render({"low": -1, "high": 1})

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -169,7 +169,6 @@ def test_controls_render_sets_menu():
             ("1", "1"), ("2", "2")]
 
 
-
 @pytest.mark.parametrize("props,palette", [
         ({}, None),
         ({"name": "Accent", "number": 3},

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -183,6 +183,18 @@ def test_controls_render_palette(props, palette):
     assert color_mapper.palette == palette
 
 
+@pytest.mark.parametrize("props,active", [
+    ({}, []),
+    ({"reverse": False}, []),
+    ({"reverse": True}, [0]),
+])
+def test_color_palette_render_checkbox(props, active):
+    color_mapper = bokeh.models.LinearColorMapper()
+    color_palette = colors.ColorPalette(color_mapper)
+    color_palette.render(props)
+    assert color_palette.checkbox.active == active
+
+
 @pytest.mark.parametrize("key,props,active", [
     ("fixed", {}, []),
     ("fixed", {"fixed": False}, []),
@@ -194,7 +206,7 @@ def test_controls_render_palette(props, palette):
     ("invisible_max", {"invisible_max": False}, []),
     ("invisible_max", {"invisible_max": True}, [0]),
 ])
-def test_controls_render_checkboxes(key, props, active):
+def test_user_limits_render_checkboxes(key, props, active):
     user_limits = colors.UserLimits()
     user_limits.render(props)
     assert user_limits.checkboxes[key].active == active

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -19,6 +19,16 @@ def test_middleware(store, action, expect):
     assert expect == result
 
 
+@pytest.mark.parametrize("state,expect", [
+    ({}, ""),
+    ({"presets": {"labels": {3: "L"}}}, ""),
+    ({"presets": {"active": 3, "labels": {3: "L"}}}, "L")
+])
+def test_query_label(state, expect):
+    result = presets.Query(state).label
+    assert expect == result
+
+
 def test_preset_set_default_mode():
     state = presets.reducer({}, presets.set_default_mode())
     assert state["presets"]["meta"]["mode"] == presets.DEFAULT
@@ -139,7 +149,7 @@ def test_reducer_save_preset_creates_presets_section():
     state = {"colorbar": settings}
     action = presets.save_preset(label)
     result = presets.reducer(state, action)
-    uid = presets.find_id(result, label)
+    uid = presets.Query(result).find_id(label)
     assert result["colorbar"] == settings
     assert result["presets"]["labels"][uid] == label
     assert result["presets"]["settings"][uid] == settings
@@ -157,9 +167,9 @@ def test_reducer_save_preset_adds_new_entry():
     action = presets.save_preset("B")
     result = presets.reducer(state, action)
     assert set(result["presets"]["labels"].values()) == {"A", "B"}
-    uid = presets.find_id(result, "A")
+    uid = presets.Query(result).find_id("A")
     assert result["presets"]["settings"][uid] == {"palette": "inferno"}
-    uid = presets.find_id(result, "B")
+    uid = presets.Query(result).find_id("B")
     assert result["presets"]["settings"][uid] == {"palette": "blues"}
 
 
@@ -183,7 +193,7 @@ def test_reducer_save_duplicate_label():
             presets.save_preset("A"),
             presets.save_preset("A")]:
         state = presets.reducer(state, action)
-    uid = presets.find_id(state, "A")
+    uid = presets.Query(state).find_id("A")
     assert set(state["presets"]["labels"].values()) == {"A"}
     assert state["presets"]["settings"][uid] == settings
 
@@ -199,7 +209,7 @@ def test_reducer_update():
             colors.set_palette_name("Accent"),
             presets.save_preset("A")]:
         state = reducer(state, action)
-    uid = presets.find_id(state, "A")
+    uid = presets.Query(state).find_id("A")
     assert state["colorbar"] == {"name": "Accent"}
     assert set(state["presets"]["labels"].values()) == {"A"}
     assert state["presets"]["settings"][uid] == {"name": "Accent"}

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -11,8 +11,14 @@ def store():
 
 
 @pytest.mark.parametrize("action,expect", [
-    (presets.on_edit(), [presets.set_edit_mode()]),
-    (presets.on_new(), [presets.set_edit_mode()]),
+    (presets.on_edit(), [
+        presets.set_edit_label(""),
+        presets.set_edit_mode()
+    ]),
+    (presets.on_new(), [
+        presets.set_edit_label(""),
+        presets.set_edit_mode()
+    ]),
 ])
 def test_middleware(store, action, expect):
     result = list(presets.middleware(store, action))
@@ -39,9 +45,14 @@ def test_preset_set_edit_mode():
     assert state["presets"]["meta"]["mode"] == presets.EDIT
 
 
+def test_preset_set_edit_label():
+    state = presets.reducer({}, presets.set_edit_label("Label"))
+    assert state["presets"]["meta"]["label"] == "Label"
+
+
 def test_state_to_props():
     result = presets.state_to_props({})
-    expect = ([], presets.DEFAULT)
+    expect = ([], presets.DEFAULT, "")
     assert expect == result
 
 
@@ -208,7 +219,7 @@ def test_reducer_update():
 ])
 def test_render(labels, options):
     ui = presets.PresetUI()
-    ui.render(labels, presets.DEFAULT)
+    ui.render(labels, presets.DEFAULT, "")
     assert ui.select.options == options
     assert isinstance(ui.select, bokeh.models.Select)
     assert isinstance(ui.buttons["save"], bokeh.models.Button)
@@ -217,8 +228,9 @@ def test_render(labels, options):
 
 def test_render_edit_mode():
     ui = presets.PresetUI()
-    ui.render([], presets.EDIT)
+    ui.render([], presets.EDIT, "Name")
     row = ui.rows["content"]
     assert isinstance(row.children[0], bokeh.models.TextInput)
     assert isinstance(row.children[1], bokeh.models.Button)
     assert isinstance(row.children[2], bokeh.models.Button)
+    assert ui.text_input.value == "Name"

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -120,7 +120,7 @@ def test__reducer_remove_preset():
 
 @pytest.mark.parametrize("call_method,action", [
     (lambda ui: ui.on_save(), presets.on_save("label")),
-    (lambda ui: ui.on_load(), presets.load_preset("label"))
+    (lambda ui: ui.on_load(None, None, "label"), presets.load_preset("label"))
 ])
 def test_ui_actions(call_method, action):
     listener = unittest.mock.Mock()

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -5,6 +5,20 @@ import bokeh.models
 from forest import presets, colors, redux
 
 
+@pytest.fixture
+def store():
+    return redux.Store(presets.reducer)
+
+
+@pytest.mark.parametrize("action,expect", [
+    (presets.on_edit(), [presets.set_edit_mode()]),
+    (presets.on_new(), [presets.set_edit_mode()]),
+])
+def test_middleware(store, action, expect):
+    result = list(presets.middleware(store, action))
+    assert expect == result
+
+
 def test_preset_set_default_mode():
     state = presets.reducer({}, presets.set_default_mode())
     assert state["presets"]["meta"]["mode"] == presets.DEFAULT

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -91,19 +91,6 @@ def test__reducer_load_preset():
     assert state["presets"]["active"] == 5
 
 
-def test__reducer_rename_preset():
-    state = {
-        "presets": {
-            "active": 7,
-            "labels": {
-                7: "Custom-1"}
-        }
-    }
-    action = presets.rename_preset("Custom-2")
-    state = presets.reducer(state, action)
-    assert state["presets"]["labels"] == {7: "Custom-2"}
-
-
 def test__reducer_remove_preset():
     state = {
         "presets": {

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -1,0 +1,213 @@
+import copy
+import pytest
+import unittest
+import bokeh.models
+from forest import presets, colors, redux
+
+
+def test_preset_set_default_mode():
+    state = presets.reducer({}, presets.set_default_mode())
+    assert state["presets"]["meta"]["mode"] == presets.DEFAULT
+
+
+def test_preset_set_edit_mode():
+    state = presets.reducer({}, presets.set_edit_mode())
+    assert state["presets"]["meta"]["mode"] == presets.EDIT
+
+
+def test_state_to_props():
+    result = presets.state_to_props({})
+    expect = ([], presets.DEFAULT)
+    assert expect == result
+
+
+def test__reducer():
+    label = "Custom-1"
+    settings = {"key": "value"}
+    state = {"colorbar": settings}
+    action = presets.save_preset(label)
+    state = presets.reducer(state, action)
+    expect = {
+        "labels": {0: label},
+        "settings": {0: settings},
+    }
+    assert state["presets"] == expect
+
+
+def test__reducer_save_new_preset():
+    label = "Custom-2"
+    settings = {"key": "value"}
+    state = {
+        "colorbar": settings,
+        "presets": {
+            "labels": {0: "Custom-1"},
+            "settings": {0: settings}
+        }
+    }
+    action = presets.save_preset("Custom-2")
+    state = presets.reducer(state, action)
+    result = state["presets"]
+    expect = {
+            "labels": {0: "Custom-1", 1: "Custom-2"},
+            "settings": {0: settings, 1: settings}}
+    assert expect == result
+
+
+def test__reducer_load_preset():
+    settings = {"key": "value"}
+    state = {
+        "presets": {
+            "labels": {5: "Custom-1"},
+            "settings": {5: settings}
+        }
+    }
+    action = presets.load_preset("Custom-1")
+    state = presets.reducer(state, action)
+    assert state["colorbar"] == settings
+    assert state["presets"]["active"] == 5
+
+
+def test__reducer_rename_preset():
+    state = {
+        "presets": {
+            "active": 7,
+            "labels": {
+                7: "Custom-1"}
+        }
+    }
+    action = presets.rename_preset("Custom-2")
+    state = presets.reducer(state, action)
+    assert state["presets"]["labels"] == {7: "Custom-2"}
+
+
+def test__reducer_remove_preset():
+    state = {
+        "presets": {
+            "active": 7,
+            "labels": {
+                7: "Custom-1"}
+        }
+    }
+    action = presets.remove_preset()
+    state = presets.reducer(state, action)
+    assert state["presets"]["labels"] == {}
+    assert "active" not in state["presets"]
+
+
+@pytest.mark.parametrize("call_method,action", [
+    (lambda ui: ui.on_save(), presets.on_save("label")),
+    (lambda ui: ui.on_load(), presets.load_preset("label"))
+])
+def test_ui_actions(call_method, action):
+    listener = unittest.mock.Mock()
+    ui = presets.PresetUI()
+    ui.select.value = "label"
+    ui.text_input.value = "label"
+    ui.subscribe(listener)
+    call_method(ui)
+    listener.assert_called_once_with(action)
+
+
+def test_reducer_given_empty_state():
+    state = {}
+    action = presets.save_preset("label")
+    assert presets.reducer(state, action) == {
+            "presets": {
+                "labels": {0: "label"},
+                "settings": {0: {}}
+            }
+    }
+
+
+def test_reducer_save_preset_creates_presets_section():
+    label = "A"
+    settings = {"palette": "accent"}
+    state = {"colorbar": settings}
+    action = presets.save_preset(label)
+    result = presets.reducer(state, action)
+    uid = presets.find_id(result, label)
+    assert result["colorbar"] == settings
+    assert result["presets"]["labels"][uid] == label
+    assert result["presets"]["settings"][uid] == settings
+
+
+def test_reducer_save_preset_adds_new_entry():
+    uid = 42
+    state = {
+        "colorbar": {"palette": "blues"},
+        "presets": {
+            "labels": {uid: "A"},
+            "settings": {uid: {"palette": "inferno"}}
+        }
+    }
+    action = presets.save_preset("B")
+    result = presets.reducer(state, action)
+    assert set(result["presets"]["labels"].values()) == {"A", "B"}
+    uid = presets.find_id(result, "A")
+    assert result["presets"]["settings"][uid] == {"palette": "inferno"}
+    uid = presets.find_id(result, "B")
+    assert result["presets"]["settings"][uid] == {"palette": "blues"}
+
+
+def test_reducer_load_preset():
+    uid = 42
+    state = {
+        "presets": {
+            "labels": {uid: "A"},
+            "settings": {uid: {"palette": "spectral"}}
+        }
+    }
+    action = presets.load_preset("A")
+    result = presets.reducer(state, action)
+    assert result["colorbar"] == {"palette": "spectral"}
+
+
+def test_reducer_save_duplicate_label():
+    settings = {"palette": "Accent"}
+    state = {"colorbar": settings}
+    for action in [
+            presets.save_preset("A"),
+            presets.save_preset("A")]:
+        state = presets.reducer(state, action)
+    uid = presets.find_id(state, "A")
+    assert set(state["presets"]["labels"].values()) == {"A"}
+    assert state["presets"]["settings"][uid] == settings
+
+
+def test_reducer_update():
+    reducer = redux.combine_reducers(
+            presets.reducer,
+            colors.reducer)
+    state = {}
+    for action in [
+            colors.set_palette_name("Viridis"),
+            presets.save_preset("A"),
+            colors.set_palette_name("Accent"),
+            presets.save_preset("A")]:
+        state = reducer(state, action)
+    uid = presets.find_id(state, "A")
+    assert state["colorbar"] == {"name": "Accent"}
+    assert set(state["presets"]["labels"].values()) == {"A"}
+    assert state["presets"]["settings"][uid] == {"name": "Accent"}
+
+
+@pytest.mark.parametrize("labels,options", [
+    ([], []),
+    (["B", "A"], ["A", "B"])
+])
+def test_render(labels, options):
+    ui = presets.PresetUI()
+    ui.render(labels, presets.DEFAULT)
+    assert ui.select.options == options
+    assert isinstance(ui.select, bokeh.models.Select)
+    assert isinstance(ui.buttons["save"], bokeh.models.Button)
+    assert isinstance(ui.layout, bokeh.layouts.Box)
+
+
+def test_render_edit_mode():
+    ui = presets.PresetUI()
+    ui.render([], presets.EDIT)
+    row = ui.rows["content"]
+    assert isinstance(row.children[0], bokeh.models.TextInput)
+    assert isinstance(row.children[1], bokeh.models.Button)
+    assert isinstance(row.children[2], bokeh.models.Button)


### PR DESCRIPTION
The ability to store colorbar settings in the application state for later retrieval

- Colorbar settings can be savable/loadable/updatable via `"presets"` key in state
- UI added to allow user to name settings, save them, load them, edit them and repeat
- Could be serialisable through I/O middleware (future PR)