### PR TITLE
Fix missing import os

### DIFF
--- a/forest/db/__init__.py
+++ b/forest/db/__init__.py
@@ -1,4 +1,5 @@
 import functools
+import os
 
 from .control import *
 from .database import *

--- a/test/test_navigator.py
+++ b/test/test_navigator.py
@@ -8,6 +8,13 @@ import forest.exceptions
 import forest.navigate as navigate
 
 
+def test_get_database_with_real_dependencies(tmpdir):
+    # Note: needed to check os library imported
+    database_path = str(tmpdir / "example.db")
+    with pytest.raises(ValueError):
+        forest.db.get_database(database_path)
+
+
 @patch('forest.navigate.Navigator._from_group')
 def test_Navigator_init(from_group):
     from_group.side_effect = [sentinel.nav1, sentinel.nav2]


### PR DESCRIPTION
- Fix `forest.db.__init__.py` missing `import os` statement