### PR TITLE
Colorbar defaults

### DIFF
--- a/forest/colors.py
+++ b/forest/colors.py
@@ -179,6 +179,14 @@ def defaults():
     }
 
 
+def complete(settings):
+    """Check current colorbar state is complete
+
+    :returns: True if every colorbar setting is present
+    """
+    return all([key in settings for key in defaults().keys()])
+
+
 def names():
     """All palette names
 
@@ -216,10 +224,11 @@ def palettes(store, action):
     elif kind == SET_LIMITS:
         yield action
     else:
-        # While handling generic action set to default if not already set
+        # While handling generic action augment with defaults if not already set
         yield action
-        if "colorbar" not in store.state:
-            yield set_colorbar(defaults())
+        settings = store.state.get("colorbar", {})
+        if not complete(settings):
+            yield set_colorbar({**defaults(), **settings})
 
 
 def is_fixed(state):

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -73,6 +73,11 @@ SET_PALETTE = "SET_PALETTE"
 SET_LIMITS = "SET_LIMITS"
 
 
+def set_colorbar(options):
+    """Action to set all colorbar settings at once"""
+    return {"kind": SET_PALETTE, "payload": options}
+
+
 def set_fixed(flag):
     """Action to set fix user-defined limits"""
     return {"kind": SET_PALETTE, "payload": {"fixed": flag}}
@@ -155,6 +160,33 @@ def reducer(state, action):
     return state
 
 
+def defaults():
+    """Default color palette settings
+
+    .. note:: incomplete settings create unintuitive behaviour when restoring
+              from a previously saved palette
+    """
+    return {
+        "name": "Viridis",
+        "names": names(),
+        "number": 256,
+        "low": 0,
+        "high": 1,
+        "fixed": False,
+        "reverse": False,
+        "invisible_min": False,
+        "invisible_max": False,
+    }
+
+
+def names():
+    """All palette names
+
+    :returns: list of valid bokeh palette names
+    """
+    return list(sorted(bokeh.palettes.all_palettes.keys()))
+
+
 def palettes(store, action):
     """Color palette middleware
 
@@ -181,8 +213,13 @@ def palettes(store, action):
                     if number not in numbers:
                         yield set_palette_number(max(numbers))
         yield action
-    else:
+    elif kind == SET_LIMITS:
         yield action
+    else:
+        # While handling generic action set to default if not already set
+        yield action
+        if "colorbar" not in store.state:
+            yield set_colorbar(defaults())
 
 
 def is_fixed(state):

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -168,8 +168,9 @@ def defaults():
     """
     return {
         "name": "Viridis",
-        "names": names(),
+        "names": palette_names(),
         "number": 256,
+        "numbers": palette_numbers("Viridis"),
         "low": 0,
         "high": 1,
         "fixed": False,
@@ -187,7 +188,7 @@ def complete(settings):
     return all([key in settings for key in defaults().keys()])
 
 
-def names():
+def palette_names():
     """All palette names
 
     :returns: list of valid bokeh palette names

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -4,6 +4,17 @@ Color palette
 
 Helpers to choose color palette(s), limits etc.
 
+UI components
+~~~~~~~~~~~~~
+
+The following components wire up the various bokeh
+widgets and event handlers to actions and react to
+changes in state. They are typically used in the
+following manner.
+
+>>> component = Component().connect(store)
+>>> bokeh.layouts.column(component.layout)
+
 .. autoclass:: ColorPalette
     :members:
 
@@ -12,6 +23,16 @@ Helpers to choose color palette(s), limits etc.
 
 .. autoclass:: SourceLimits
     :members:
+
+Most components are not interested in the full application
+state. The :func:`connect` method and :func:`state_to_props`
+are provided to only notify UI components when relevant state
+updates.
+
+.. autofunction:: connect
+
+.. autofunction:: state_to_props
+
 
 Reducer
 ~~~~~~~
@@ -28,6 +49,17 @@ Middleware pre-processes actions prior to the reducer
 
 .. autofunction:: palettes
 
+Helpers
+~~~~~~~
+
+Convenient functions to simplify color bar settings
+
+.. autofunction:: defaults
+
+.. autofunction:: palette_names
+
+.. autofunction:: palette_numbers
+
 Actions
 ~~~~~~~
 
@@ -35,6 +67,8 @@ Actions are small pieces of data used to communicate
 with other parts of the system. Reducers and
 middleware functions can interpret their contents
 and either update state or generate new actions
+
+.. autofunction:: set_colorbar
 
 .. autofunction:: set_fixed
 
@@ -74,7 +108,7 @@ SET_LIMITS = "SET_LIMITS"
 
 
 def set_colorbar(options):
-    """Action to set all colorbar settings at once"""
+    """Action to set multiple settings at once"""
     return {"kind": SET_PALETTE, "payload": options}
 
 
@@ -163,8 +197,25 @@ def reducer(state, action):
 def defaults():
     """Default color palette settings
 
+    .. code-block:: python
+
+        {
+            "name": "Viridis",
+            "names": palette_names(),
+            "number": 256,
+            "numbers": palette_numbers("Viridis"),
+            "low": 0,
+            "high": 1,
+            "fixed": False,
+            "reverse": False,
+            "invisible_min": False,
+            "invisible_max": False,
+        }
+
     .. note:: incomplete settings create unintuitive behaviour when restoring
               from a previously saved palette
+
+    :returns: dict representing default colorbar
     """
     return {
         "name": "Viridis",
@@ -238,12 +289,27 @@ def is_fixed(state):
 
 
 def palette_numbers(name):
-    """Helper to choose available color palette numbers"""
+    """Helper to choose available color palette numbers
+
+    :returns: list of valid bokeh palette numbers
+    """
     return list(sorted(bokeh.palettes.all_palettes[name].keys()))
 
 
 class SourceLimits(Observable):
-    """Event stream listening to collection of ColumnDataSources"""
+    """Event stream listening to collection of ColumnDataSources
+
+    Translates column data source on_change events into domain
+    specific actions, e.g. :func:`set_source_limits`. Instead
+    of connecting to a :class:`forest.redux.Store`, simply
+    subscribe ``store.dispatch`` to action events.
+
+    >>> source_limits = SourceLimits(sources)
+    >>> source_limits.subscribe(store.dispatch)
+
+    .. note:: Unlike a typical component there is no ``layout`` property
+              to attach to a bokeh document
+    """
     def __init__(self, sources):
         self.sources = sources
         for source in self.sources:
@@ -304,6 +370,7 @@ class UserLimits(Observable):
         :type store: :class:`forest.redux.Store`
         """
         connect(self, store)
+        return self
 
     def on_checkbox_change(self, attr, old, new):
         self.notify(set_fixed(len(new) == 1))
@@ -331,12 +398,27 @@ class UserLimits(Observable):
 
 
 def state_to_props(state):
-    """Map state to props relevant to component"""
+    """Map state to props relevant to component
+
+    :param state: dict representing full application state
+    :returns: ``state["colorbar"]`` or ``None``
+    """
     return state.get("colorbar", None)
 
 
 def connect(view, store):
-    """Connect component to Store"""
+    """Connect component to Store
+
+    UI components connected to a Store
+    only need to be notified when a change occurs that
+    is relevant to them, all other state updates can be
+    safely ignored.
+
+    To implement component specific updates this helper method
+    listens to store dispatch events, converts them
+    to a stream of states, maps the states to
+    props and filters out duplicates.
+    """
     view.subscribe(store.dispatch)
     stream = (Stream()
                 .listen_to(store)
@@ -372,6 +454,7 @@ class ColorPalette(Observable):
     def connect(self, store):
         """Connect component to Store"""
         connect(self, store)
+        return self
 
     def on_name(self, attr, old, new):
         """Event-handler when a palette name is selected"""

--- a/forest/main.py
+++ b/forest/main.py
@@ -283,10 +283,6 @@ def main(argv=None):
     # Connect color palette controls
     color_palette = colors.ColorPalette(color_mapper)
     color_palette.connect(store)
-    names = list(sorted(bokeh.palettes.all_palettes.keys()))
-    store.dispatch(colors.set_palette_name("Viridis"))
-    store.dispatch(colors.set_palette_number(256))
-    store.dispatch(colors.set_palette_names(names))
 
     # Connect limit controllers to store
     source_limits = colors.SourceLimits(image_sources)

--- a/forest/main.py
+++ b/forest/main.py
@@ -281,15 +281,13 @@ def main(argv=None):
         middlewares=middlewares)
 
     # Connect color palette controls
-    color_palette = colors.ColorPalette(color_mapper)
-    color_palette.connect(store)
+    color_palette = colors.ColorPalette(color_mapper).connect(store)
 
     # Connect limit controllers to store
     source_limits = colors.SourceLimits(image_sources)
     source_limits.subscribe(store.dispatch)
 
-    user_limits = colors.UserLimits()
-    user_limits.connect(store)
+    user_limits = colors.UserLimits().connect(store)
 
     # Connect navigation controls
     controls = db.ControlView()

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -70,6 +70,16 @@ def test_middleware_given_empty_state_emits_set_colorbar():
     expect = [action, colors.set_colorbar(colors.defaults())]
     assert expect == result
 
+
+def test_middleware_given_incomplete_state_emits_set_colorbar():
+    store = redux.Store(colors.reducer, initial_state={"colorbar": {"low": -1}})
+    action = {"kind": "ANY"}
+    result = list(colors.palettes(store, action))
+    settings = {**colors.defaults(), **{"low": -1}}
+    expect = [action, colors.set_colorbar(settings)]
+    assert expect == result
+
+
 def test_middleware_given_set_name_emits_set_numbers():
     store = redux.Store(colors.reducer)
     action = colors.set_palette_name("Blues")

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -36,8 +36,9 @@ def test_reducer_immutable_state():
 def test_defaults():
     expected = {
         "name": "Viridis",
-        "names": colors.names(),
         "number": 256,
+        "names": colors.palette_names(),
+        "numbers": colors.palette_numbers("Viridis"),
         "low": 0,
         "high": 1,
         "fixed": False,

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -19,6 +19,8 @@ def listener():
     ({}, colors.set_user_high(100), {"colorbar": {"high": 100}}),
     ({}, colors.set_user_low(0), {"colorbar": {"low": 0}}),
     ({}, colors.set_source_limits(0, 100), {"colorbar": {"low": 0, "high": 100}}),
+    ({}, colors.set_colorbar({"key": "value"}), {"colorbar": {"key": "value"}}),
+    ({}, colors.set_palette_names(["example"]), {"colorbar": {"names": ["example"]}}),
 ])
 def test_reducer(state, action, expect):
     result = colors.reducer(state, action)
@@ -29,6 +31,21 @@ def test_reducer_immutable_state():
     state = {"colorbar": {"number": 1}}
     colors.reducer(state, colors.set_palette_number(3))
     assert state["colorbar"]["number"] == 1
+
+
+def test_defaults():
+    expected = {
+        "name": "Viridis",
+        "names": colors.names(),
+        "number": 256,
+        "low": 0,
+        "high": 1,
+        "fixed": False,
+        "reverse": False,
+        "invisible_min": False,
+        "invisible_max": False
+    }
+    assert colors.defaults() == expected
 
 
 def test_color_controls():
@@ -45,6 +62,13 @@ def test_controls_on_name(listener):
     controls.on_number(None, None, 5)
     listener.assert_called_once_with(colors.set_palette_number(5))
 
+
+def test_middleware_given_empty_state_emits_set_colorbar():
+    store = redux.Store(colors.reducer)
+    action = {"kind": "ANY"}
+    result = list(colors.palettes(store, action))
+    expect = [action, colors.set_colorbar(colors.defaults())]
+    assert expect == result
 
 def test_middleware_given_set_name_emits_set_numbers():
     store = redux.Store(colors.reducer)


### PR DESCRIPTION
This PR makes implementing presets much simpler in two ways:

- By always having a complete dictionary of colorbar settings in the application state saving/loading colorbars becomes trivial

- Less bolierplate code is needed to correctly instantiate `colors.ColorPalette` UI component in `main.py`