### PR TITLE
Preset storage

### DIFF
--- a/forest/main.py
+++ b/forest/main.py
@@ -272,7 +272,7 @@ def main(argv=None):
             "inital_times": db.stamps
         }),
         colors.palettes,
-        presets.Middleware(presets.Storage()),
+        presets.Middleware(presets.proxy_storage()),
         presets.middleware,
     ]
     store = redux.Store(

--- a/forest/main.py
+++ b/forest/main.py
@@ -272,7 +272,8 @@ def main(argv=None):
             "inital_times": db.stamps
         }),
         colors.palettes,
-        presets.middleware
+        presets.Middleware(presets.Storage()),
+        presets.middleware,
     ]
     store = redux.Store(
         redux.combine_reducers(

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -135,10 +135,16 @@ class Middleware:
         self.storage = storage
 
     def __call__(self, store, action):
+        kind = action["kind"]
+        if kind == PRESET_ON_SAVE:
+            label = action["payload"]
+            settings = copy.deepcopy(store.state.get("colorbar", {}))
+            self.storage.save(label, settings)
         yield action
 
 
 class Storage:
+    """Store preset settings in-memory"""
     def __init__(self):
         self._records = {}
 

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -144,7 +144,7 @@ class Middleware:
         kind = action["kind"]
         if kind == PRESET_ON_SAVE:
             label = action["payload"]
-            settings = copy.deepcopy(store.state.get("colorbar", {}))
+            settings = store.state.get("colorbar", {})
             self.storage.save(label, settings)
         elif kind == PRESET_ON_LOAD:
             label = action["payload"]
@@ -153,7 +153,11 @@ class Middleware:
 
 
 class Storage:
-    """Store preset settings in-memory"""
+    """Store colorbar settings in memory
+
+    .. note:: :py:func:`copy.deepcopy` is used to prevent mutable
+              references to stored data
+    """
     def __init__(self):
         self._records = {}
 
@@ -161,10 +165,10 @@ class Storage:
         return [key for key in self._records.keys()]
 
     def save(self, label, settings):
-        self._records[label] = settings
+        self._records[label] = copy.deepcopy(settings)
 
     def load(self, label):
-        return self._records[label]
+        return copy.deepcopy(self._records[label])
 
 
 def middleware(store, action):
@@ -210,14 +214,7 @@ def reducer(state, action):
             state["presets"] = {}
         if "labels" not in state["presets"]:
             state["presets"]["labels"] = {}
-        if "settings" not in state["presets"]:
-            state["presets"]["settings"] = {}
         state["presets"]["labels"][uid] = label
-        if "colorbar" in state:
-            settings = copy.deepcopy(state["colorbar"])
-        else:
-            settings = {}
-        state["presets"]["settings"][uid] = settings
 
     elif kind == PRESET_LOAD:
         label = action["payload"]

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -57,7 +57,7 @@ import copy
 import bokeh.models
 import bokeh.layouts
 from forest.observe import Observable
-from forest import redux, rx
+from forest import colors, redux, rx
 
 # Action kinds
 PRESET_SAVE = "PRESET_SAVE"
@@ -146,6 +146,9 @@ class Middleware:
             label = action["payload"]
             settings = copy.deepcopy(store.state.get("colorbar", {}))
             self.storage.save(label, settings)
+        elif kind == PRESET_ON_LOAD:
+            label = action["payload"]
+            yield colors.set_colorbar(self.storage.load(label))
         yield action
 
 
@@ -219,9 +222,6 @@ def reducer(state, action):
     elif kind == PRESET_LOAD:
         label = action["payload"]
         uid = Query(state).find_id(label)
-        settings = copy.deepcopy(state["presets"]["settings"][uid])
-        print(label, uid, settings)
-        state["colorbar"] = settings
         state["presets"]["active"] = uid
     elif kind == PRESET_REMOVE:
         uid = state["presets"]["active"]

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -130,6 +130,28 @@ def state_to_props(state):
     return query.labels, query.display_mode, query.edit_label
 
 
+class Middleware:
+    def __init__(self, storage):
+        self.storage = storage
+
+    def __call__(self, store, action):
+        yield action
+
+
+class Storage:
+    def __init__(self):
+        self._records = {}
+
+    def labels(self):
+        return [key for key in self._records.keys()]
+
+    def save(self, label, settings):
+        self._records[label] = settings
+
+    def load(self, label):
+        return self._records[label]
+
+
 def middleware(store, action):
     """Presets middleware
 

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -65,6 +65,7 @@ PRESET_LOAD = "PRESET_LOAD"
 PRESET_REMOVE = "PRESET_REMOVE"
 PRESET_SET_META = "PRESET_SET_META"
 PRESET_ON_SAVE = "PRESET_ON_SAVE"
+PRESET_ON_LOAD = "PRESET_ON_LOAD"
 PRESET_ON_NEW = "PRESET_ON_NEW"
 PRESET_ON_EDIT = "PRESET_ON_EDIT"
 PRESET_ON_CANCEL = "PRESET_ON_CANCEL"
@@ -107,6 +108,11 @@ def set_edit_label(label):
 def on_save(label):
     """Action to signal save clicked"""
     return {"kind": PRESET_ON_SAVE, "payload": label}
+
+
+def on_load(label):
+    """Action to signal load clicked"""
+    return {"kind": PRESET_ON_LOAD, "payload": label}
 
 
 def on_edit():
@@ -169,6 +175,9 @@ def middleware(store, action):
     if kind == PRESET_ON_SAVE:
         yield save_preset(action["payload"])
         yield set_default_mode()
+    elif kind == PRESET_ON_LOAD:
+        # Translate on_load() to load_preset() action
+        yield load_preset(action["payload"])
     elif kind == PRESET_ON_CANCEL:
         yield set_default_mode()
     elif kind == PRESET_ON_EDIT:
@@ -336,7 +345,7 @@ class PresetUI(Observable):
 
     def on_load(self, attr, old, new):
         """Notify listeners that a load action has taken place"""
-        self.notify(load_preset(new))
+        self.notify(on_load(new))
 
     def on_new(self):
         self.notify(on_new())

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -167,8 +167,11 @@ class Middleware:
             label = action["payload"]
             yield colors.set_colorbar(self.storage.load(label))
         else:
-            labels = self.storage.labels()
-            if len(labels) > 0:
+            # Maintain label consistency between storage and state
+            state_labels = Query(store.state).labels
+            storage_labels = self.storage.labels()
+            if len(set(state_labels) ^ set(storage_labels)) > 0:
+                labels = list(set(state_labels) | set(storage_labels))
                 yield set_labels(labels)
         yield action
 

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -118,7 +118,7 @@ def test__reducer_remove_preset():
 
 @pytest.mark.parametrize("call_method,action", [
     (lambda ui: ui.on_save(), presets.on_save("label")),
-    (lambda ui: ui.on_load(None, None, "label"), presets.load_preset("label"))
+    (lambda ui: ui.on_load(None, None, "label"), presets.on_load("label"))
 ])
 def test_ui_actions(call_method, action):
     listener = unittest.mock.Mock()

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -93,12 +93,10 @@ def test__reducer_load_preset():
     state = {
         "presets": {
             "labels": {5: "Custom-1"},
-            "settings": {5: settings}
         }
     }
     action = presets.load_preset("Custom-1")
     state = presets.reducer(state, action)
-    assert state["colorbar"] == settings
     assert state["presets"]["active"] == 5
 
 
@@ -169,19 +167,6 @@ def test_reducer_save_preset_adds_new_entry():
     assert result["presets"]["settings"][uid] == {"palette": "inferno"}
     uid = presets.Query(result).find_id("B")
     assert result["presets"]["settings"][uid] == {"palette": "blues"}
-
-
-def test_reducer_load_preset():
-    uid = 42
-    state = {
-        "presets": {
-            "labels": {uid: "A"},
-            "settings": {uid: {"palette": "spectral"}}
-        }
-    }
-    action = presets.load_preset("A")
-    result = presets.reducer(state, action)
-    assert result["colorbar"] == {"palette": "spectral"}
 
 
 def test_reducer_save_duplicate_label():

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -25,6 +25,12 @@ def test_middleware(store, action, expect):
     assert expect == result
 
 
+def test_reducer_set_labels():
+    labels = ["A"]
+    state = presets.reducer({}, presets.set_labels(labels))
+    assert set(labels) == set(state["presets"]["labels"].values())
+
+
 @pytest.mark.parametrize("state,expect", [
     ({}, ""),
     ({"presets": {"labels": {3: "L"}}}, ""),

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -56,35 +56,27 @@ def test_state_to_props():
     assert expect == result
 
 
-def test__reducer():
+def test_reducer_save_preset():
     label = "Custom-1"
-    settings = {"key": "value"}
-    state = {"colorbar": settings}
+    state = {"colorbar": {"key": "value"}}
     action = presets.save_preset(label)
     state = presets.reducer(state, action)
-    expect = {
-        "labels": {0: label},
-        "settings": {0: settings},
-    }
+    expect = {"labels": {0: label}}
     assert state["presets"] == expect
 
 
-def test__reducer_save_new_preset():
+def test_reducer_save_new_preset():
     label = "Custom-2"
-    settings = {"key": "value"}
     state = {
-        "colorbar": settings,
+        "colorbar": {"key": "value"},
         "presets": {
-            "labels": {0: "Custom-1"},
-            "settings": {0: settings}
+            "labels": {0: "Custom-1"}
         }
     }
     action = presets.save_preset("Custom-2")
     state = presets.reducer(state, action)
     result = state["presets"]
-    expect = {
-            "labels": {0: "Custom-1", 1: "Custom-2"},
-            "settings": {0: settings, 1: settings}}
+    expect = {"labels": {0: "Custom-1", 1: "Custom-2"}}
     assert expect == result
 
 
@@ -133,52 +125,30 @@ def test_reducer_given_empty_state():
     action = presets.save_preset("label")
     assert presets.reducer(state, action) == {
             "presets": {
-                "labels": {0: "label"},
-                "settings": {0: {}}
+                "labels": {0: "label"}
             }
     }
 
 
 def test_reducer_save_preset_creates_presets_section():
     label = "A"
-    settings = {"palette": "accent"}
-    state = {"colorbar": settings}
+    state = {"colorbar": {}}
     action = presets.save_preset(label)
     result = presets.reducer(state, action)
     uid = presets.Query(result).find_id(label)
-    assert result["colorbar"] == settings
     assert result["presets"]["labels"][uid] == label
-    assert result["presets"]["settings"][uid] == settings
 
 
 def test_reducer_save_preset_adds_new_entry():
     uid = 42
     state = {
-        "colorbar": {"palette": "blues"},
         "presets": {
             "labels": {uid: "A"},
-            "settings": {uid: {"palette": "inferno"}}
         }
     }
     action = presets.save_preset("B")
     result = presets.reducer(state, action)
     assert set(result["presets"]["labels"].values()) == {"A", "B"}
-    uid = presets.Query(result).find_id("A")
-    assert result["presets"]["settings"][uid] == {"palette": "inferno"}
-    uid = presets.Query(result).find_id("B")
-    assert result["presets"]["settings"][uid] == {"palette": "blues"}
-
-
-def test_reducer_save_duplicate_label():
-    settings = {"palette": "Accent"}
-    state = {"colorbar": settings}
-    for action in [
-            presets.save_preset("A"),
-            presets.save_preset("A")]:
-        state = presets.reducer(state, action)
-    uid = presets.Query(state).find_id("A")
-    assert set(state["presets"]["labels"].values()) == {"A"}
-    assert state["presets"]["settings"][uid] == settings
 
 
 def test_reducer_update():
@@ -187,15 +157,10 @@ def test_reducer_update():
             colors.reducer)
     state = {}
     for action in [
-            colors.set_palette_name("Viridis"),
             presets.save_preset("A"),
-            colors.set_palette_name("Accent"),
             presets.save_preset("A")]:
         state = reducer(state, action)
-    uid = presets.Query(state).find_id("A")
-    assert state["colorbar"] == {"name": "Accent"}
     assert set(state["presets"]["labels"].values()) == {"A"}
-    assert state["presets"]["settings"][uid] == {"name": "Accent"}
 
 
 @pytest.mark.parametrize("labels,options", [

--- a/test/test_presets_storage.py
+++ b/test/test_presets_storage.py
@@ -1,5 +1,5 @@
 import pytest
-from forest import presets, redux
+from forest import presets, colors, redux
 
 
 @pytest.fixture
@@ -38,3 +38,15 @@ def test_storage_middleware_given_on_save_copies_colorbar():
     list(middleware(store, action))
     store.state["colorbar"]["K"] = "T"
     assert storage.load("label") == {"K": "V"}
+
+
+def test_storage_middleware_on_load(store):
+    label = "label"
+    settings = {"key": "value"}
+    storage = presets.Storage()
+    storage.save(label, settings)
+    middleware = presets.Middleware(storage)
+    action = presets.on_load(label)
+    result = list(middleware(store, action))
+    expect = [colors.set_colorbar(settings), action]
+    assert expect == result

--- a/test/test_presets_storage.py
+++ b/test/test_presets_storage.py
@@ -7,6 +7,39 @@ def store():
     return redux.Store(presets.reducer)
 
 
+def test_storage_save_new():
+    storage = presets.Storage()
+    storage.save("label", {"key": "value"})
+    assert storage.load("label") == {"key": "value"}
+
+
+def test_storage_save_update():
+    storage = presets.Storage()
+    storage.save("label", {"key": "old"})
+    storage.save("label", {"key": "new"})
+    assert storage.load("label") == {"key": "new"}
+
+
+def test_storage_save_copy():
+    """Stored data must not be reference to mutable dict"""
+    data = {"key": "old"}
+    storage = presets.Storage()
+    storage.save("label", data)
+    data["key"] = "new"
+    assert storage.load("label") == {"key": "old"}
+
+
+def test_storage_load_copy():
+    """Loaded data must not reference a mutable dict"""
+    data = {"key": "old"}
+    storage = presets.Storage()
+    storage.save("label", data)
+    loaded = storage.load("label")
+    loaded["key"] = "mutate"  # Should not edit data inside Storage
+    result = storage.load("label")
+    assert result == {"key": "old"}
+
+
 def test_storage():
     storage = presets.Storage()
     storage.save("label", {"key": "value"})

--- a/test/test_presets_storage.py
+++ b/test/test_presets_storage.py
@@ -49,7 +49,6 @@ def test_storage():
 
 def test_storage_middleware(store):
     storage = presets.Storage()
-    storage.save("label", {"key": "value"})
     action = {"kind": "ANY"}
     middleware = presets.Middleware(storage)
     assert list(middleware(store, action)) == [action]
@@ -82,4 +81,15 @@ def test_storage_middleware_on_load(store):
     action = presets.on_load(label)
     result = list(middleware(store, action))
     expect = [colors.set_colorbar(settings), action]
+    assert expect == result
+
+
+def test_storage_middleware_sets_labels(store):
+    label = "label"
+    storage = presets.Storage()
+    storage.save(label, {})
+    middleware = presets.Middleware(storage)
+    action = {"kind": "ANY"}
+    result = list(middleware(store, action))
+    expect = [presets.set_labels([label]), action]
     assert expect == result

--- a/test/test_presets_storage.py
+++ b/test/test_presets_storage.py
@@ -20,3 +20,21 @@ def test_storage_middleware(store):
     action = {"kind": "ANY"}
     middleware = presets.Middleware(storage)
     assert list(middleware(store, action)) == [action]
+
+
+def test_storage_middleware_given_on_save(store):
+    storage = presets.Storage()
+    action = presets.on_save("label")
+    middleware = presets.Middleware(storage)
+    list(middleware(store, action))
+    assert storage.load("label") == {}
+
+
+def test_storage_middleware_given_on_save_copies_colorbar():
+    store = redux.Store(presets.reducer, initial_state={"colorbar": {"K": "V"}})
+    storage = presets.Storage()
+    action = presets.on_save("label")
+    middleware = presets.Middleware(storage)
+    list(middleware(store, action))
+    store.state["colorbar"]["K"] = "T"
+    assert storage.load("label") == {"K": "V"}

--- a/test/test_presets_storage.py
+++ b/test/test_presets_storage.py
@@ -1,0 +1,22 @@
+import pytest
+from forest import presets, redux
+
+
+@pytest.fixture
+def store():
+    return redux.Store(presets.reducer)
+
+
+def test_storage():
+    storage = presets.Storage()
+    storage.save("label", {"key": "value"})
+    assert storage.load("label") == {"key": "value"}
+    assert storage.labels() == ["label"]
+
+
+def test_storage_middleware(store):
+    storage = presets.Storage()
+    storage.save("label", {"key": "value"})
+    action = {"kind": "ANY"}
+    middleware = presets.Middleware(storage)
+    assert list(middleware(store, action)) == [action]


### PR DESCRIPTION
Preset storage should move from Application State tree to a dedicated I/O or in-memory object, thus enabling persistence beyond the lifetime of a single session

**TODO**
- Simplify reducer since it no longer needs complicated database-like logic, e.g. unique ID generation
- Implement disk based Storage object and solidify interface, e.g. `storage.load(label)` etc.
- Change middleware to emit actions like `set_labels(["name"])` instead of maintaining a full dict
- Simplify `state_to_props` since moving presets to `Storage` reduces parsing complexity