### PR TITLE
Preset support JSON file

### DIFF
--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -7,6 +7,9 @@ here to aid future users and maintainers.
 0.5.0
 -----
 
+- Presets are available to save colorbar settings. Additionally,
+  a location on disk can be specified in the config file
+  to maintain settings beyond the lifetime of the application
 - Refactor colors.py to use redux pattern
 - Refactor time series to use redux pattern
 - Add Python 3.8 support by modifying sqlite3 usage

--- a/forest/config.py
+++ b/forest/config.py
@@ -69,7 +69,20 @@ class Config(object):
 
     @property
     def presets_file(self):
-        """Colorbar presets configuration file"""
+        """Colorbar presets JSON file
+
+        A location on disk where colorbar settings can be saved/loaded. If
+        the file does not exist it will be created by the application.
+
+        Use the following syntax to declare the presets file location
+
+        .. code-block:: yaml
+
+            presets:
+              file: ${HOME}/example/preset-save.json
+
+        :returns: location on disk to save colorbar presets
+        """
         return self.data.get("presets", {}).get("file", None)
 
     @property

--- a/forest/config.py
+++ b/forest/config.py
@@ -68,6 +68,11 @@ class Config(object):
                 self.data)
 
     @property
+    def presets_file(self):
+        """Colorbar presets configuration file"""
+        return self.data.get("presets", {}).get("file", None)
+
+    @property
     def patterns(self):
         if "files" in self.data:
             return [(f["label"], f["pattern"])

--- a/forest/main.py
+++ b/forest/main.py
@@ -272,7 +272,7 @@ def main(argv=None):
             "inital_times": db.stamps
         }),
         colors.palettes,
-        presets.Middleware(presets.proxy_storage()),
+        presets.Middleware(presets.proxy_storage(config.presets_file)),
         presets.middleware,
     ]
     store = redux.Store(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ iris
 intake
 intake-esm
 pygrib
+libwebp=1.0.2  # Pin to prevent Travis issue

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -189,3 +189,13 @@ def test_config_parser_given_json(tmpdir):
     assert group.label == "Hello"
     assert group.pattern == "*.nc"
     assert group.locator == "file_system"
+
+
+@pytest.mark.parametrize("data,expect", [
+    ({}, None),
+    ({"presets": {}}, None),
+    ({"presets": {"file": "/some.json"}}, "/some.json")
+])
+def test_config_parser_presets_file(data, expect):
+    config = forest.config.Config(data)
+    assert config.presets_file == expect

--- a/test/test_presets_storage.py
+++ b/test/test_presets_storage.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from forest import presets, colors, redux
 
 
@@ -92,4 +93,25 @@ def test_storage_middleware_sets_labels(store):
     action = {"kind": "ANY"}
     result = list(middleware(store, action))
     expect = [presets.set_labels([label]), action]
+    assert expect == result
+
+
+def test_storage_json_save(tmpdir):
+    path = str(tmpdir / "storage.json")
+    storage = presets.Storage(path)
+    storage.save("label", {"key": "value"})
+    with open(path) as stream:
+        result = json.load(stream)
+    expect = {"label": {"key": "value"}}
+    assert expect == result
+
+
+def test_storage_json_load(tmpdir):
+    path = str(tmpdir / "storage.json")
+    data = {"label": {"key": "value"}}
+    with open(path, "w") as stream:
+        result = json.dump(data, stream)
+    storage = presets.Storage(path)
+    result = storage.load("label")
+    expect = {"key": "value"}
     assert expect == result


### PR DESCRIPTION
This PR builds on previous preset functionality to allow serialisation to/from JSON so that settings can persist beyond the server lifetime

- [x] Add docs to describe additional config file settings
- [x] Add release notes

#### Additional configuration file support

A user can optionally specify a location on disk to store colorbar settings in JSON format

```yaml
presets:
    file: ${HOME}/tutorial/preset-save.json
files:
   ...
```

