### PR TITLE
Numpy JSON serialisation for Presets

### DIFF
--- a/forest/encode.py
+++ b/forest/encode.py
@@ -1,0 +1,12 @@
+import json
+import numpy as np
+
+
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.integer):
+            return int(obj)
+        else:
+            return super().default(obj)

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -58,7 +58,7 @@ import copy
 import bokeh.models
 import bokeh.layouts
 from forest.observe import Observable
-from forest import colors, redux, rx
+from forest import colors, redux, rx, encode
 
 # Action kinds
 PRESET_SAVE = "PRESET_SAVE"
@@ -204,7 +204,7 @@ class Storage:
         self._records[label] = copy.deepcopy(settings)
         if self.file_name is not None:
             with open(self.file_name, "w") as stream:
-                json.dump(self._records, stream)
+                json.dump(self._records, stream, cls=encode.NumpyEncoder)
 
     def load(self, label):
         return copy.deepcopy(self._records[label])

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -1,0 +1,13 @@
+import pytest
+import json
+import numpy as np
+from forest import encode
+
+
+@pytest.mark.parametrize("value,expect", [
+    (0, "0"),
+    (np.int32(0), "0"),
+    (np.float32(0.), "0.0"),
+])
+def test_json_serialize_float32(value, expect):
+    assert expect == json.dumps(value, cls=encode.NumpyEncoder)

--- a/test/test_presets_storage.py
+++ b/test/test_presets_storage.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import numpy as np
 from forest import presets, colors, redux
 
 
@@ -96,13 +97,17 @@ def test_storage_middleware_sets_labels(store):
     assert expect == result
 
 
-def test_storage_json_save(tmpdir):
+@pytest.mark.parametrize("in_value,out_value", [
+    ("value", "value"),
+    (np.float32(0.), 0.),
+])
+def test_storage_json_save(tmpdir, in_value, out_value):
     path = str(tmpdir / "storage.json")
     storage = presets.Storage(path)
-    storage.save("label", {"key": "value"})
+    storage.save("label", {"key": in_value})
     with open(path) as stream:
         result = json.load(stream)
-    expect = {"label": {"key": "value"}}
+    expect = {"label": {"key": out_value}}
     assert expect == result
 
 


### PR DESCRIPTION
Colorbar settings generated by ColumnDataSource data are not always JSON serialisable, for example, `np.float32` is not JSON serialisable. This PR implements a simple `JSONEncoder` extension to support `np.floating` and `np.integer` instances, e.g. `np.float64`, `np.uint8` etc.