### PR TITLE
Rename Observable.subscribe to Observable.add_subscriber

### DIFF
--- a/forest/colors.py
+++ b/forest/colors.py
@@ -305,7 +305,7 @@ class SourceLimits(Observable):
     subscribe ``store.dispatch`` to action events.
 
     >>> source_limits = SourceLimits(sources)
-    >>> source_limits.subscribe(store.dispatch)
+    >>> source_limits.add_subscriber(store.dispatch)
 
     .. note:: Unlike a typical component there is no ``layout`` property
               to attach to a bokeh document
@@ -434,7 +434,7 @@ def connect(view, store):
     to a stream of states, maps the states to
     props and filters out duplicates.
     """
-    view.subscribe(store.dispatch)
+    view.add_subscriber(store.dispatch)
     stream = (Stream()
                 .listen_to(store)
                 .map(state_to_props)

--- a/forest/layers.py
+++ b/forest/layers.py
@@ -404,7 +404,7 @@ class Artist:
 
     def connect(self, store):
         """Connect component to the store"""
-        store.subscribe(self.render)
+        store.add_subscriber(self.render)
         return self
 
     def render(self, state: dict):

--- a/forest/main.py
+++ b/forest/main.py
@@ -252,7 +252,7 @@ def main(argv=None):
     artist.connect(store)
 
     # Connect layers controls
-    layers_ui.subscribe(store.dispatch)
+    layers_ui.add_subscriber(store.dispatch)
     layers_ui.connect(store)
 
     # Connect tools controls
@@ -261,7 +261,7 @@ def main(argv=None):
 
     # Connect figure controls/views
     figure_ui = layers.FigureUI()
-    figure_ui.subscribe(store.dispatch)
+    figure_ui.add_subscriber(store.dispatch)
     figure_row.connect(store)
 
     # Connect color palette controls
@@ -269,7 +269,7 @@ def main(argv=None):
 
     # Connect limit controllers to store
     source_limits = colors.SourceLimits(image_sources)
-    source_limits.subscribe(store.dispatch)
+    source_limits.add_subscriber(store.dispatch)
 
     user_limits = colors.UserLimits().connect(store)
 
@@ -278,8 +278,8 @@ def main(argv=None):
 
     # Connect navigation controls
     controls = db.ControlView()
-    controls.subscribe(store.dispatch)
-    store.subscribe(controls.render)
+    controls.add_subscriber(store.dispatch)
+    store.add_subscriber(controls.render)
 
     def old_world(state):
         kwargs = {k: state.get(k, None) for k in db.State._fields}
@@ -354,7 +354,7 @@ def main(argv=None):
     series_view = series.SeriesView.from_groups(
             series_figure,
             config.file_groups)
-    series_view.subscribe(store.dispatch)
+    series_view.add_subscriber(store.dispatch)
     series_args = (rx.Stream()
                 .listen_to(store)
                 .map(series.select_args)
@@ -406,7 +406,7 @@ def main(argv=None):
 
     # Add key press support
     key_press = keys.KeyPress()
-    key_press.subscribe(store.dispatch)
+    key_press.add_subscriber(store.dispatch)
 
     document = bokeh.plotting.curdoc()
     document.title = "FOREST"

--- a/forest/observe.py
+++ b/forest/observe.py
@@ -17,7 +17,7 @@ class Observable(object):
     def __init__(self):
         self.subscribers = []
 
-    def subscribe(self, method):
+    def add_subscriber(self, method):
         """Append method to list of subscribers"""
         self.subscribers.append(method)
 

--- a/forest/presets.py
+++ b/forest/presets.py
@@ -375,7 +375,7 @@ class PresetUI(Observable):
 
     def connect(self, store):
         """Convenient method to map state to props needed by render"""
-        self.subscribe(store.dispatch)
+        self.add_subscriber(store.dispatch)
         stream = (rx.Stream()
                     .listen_to(store)
                     .map(state_to_props)

--- a/forest/redux.py
+++ b/forest/redux.py
@@ -73,7 +73,7 @@ class Store(Observable):
     themselves with the store to receive the latest states as and
     when they are created.
 
-    >>> store.subscribe(listener)
+    >>> store.add_subscriber(listener)
 
     :param reducer: function combines action and state to produce new state
     :param initial_state: optional initial state, default {}

--- a/forest/rx.py
+++ b/forest/rx.py
@@ -26,7 +26,7 @@ class Stream(Observable):
 
         :returns: current stream
         """
-        observable.subscribe(self.notify)
+        observable.add_subscriber(self.notify)
         return self
 
     def map(self, f):
@@ -37,7 +37,7 @@ class Stream(Observable):
         stream = Stream()
         def callback(x):
             stream.notify(f(x))
-        self.subscribe(callback)
+        self.add_subscriber(callback)
         return stream
 
     def distinct(self):
@@ -61,7 +61,7 @@ class Stream(Observable):
                     stream.notify(x)
             return callback
 
-        self.subscribe(closure())
+        self.add_subscriber(closure())
         return stream
 
     def filter(self, f):
@@ -73,5 +73,5 @@ class Stream(Observable):
         def callback(x):
             if f(x):
                 stream.notify(x)
-        self.subscribe(callback)
+        self.add_subscriber(callback)
         return stream

--- a/forest/series.py
+++ b/forest/series.py
@@ -153,7 +153,7 @@ class ToolsPanel(Observable):
 
     def connect(self, store):
         # this should only subscribe to a tool-button-toggle state change in the store?
-        self.subscribe(store.dispatch)
+        self.add_subscriber(store.dispatch)
         
         return self
 
@@ -171,7 +171,7 @@ class ToolLayout:
         self.tool_figure = tool_figure
 
     def connect(self, store):
-        store.subscribe(self.render)
+        store.add_subscriber(self.render)
 
     def render(self, state):
         if state.get("time_series_visible"):

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -59,7 +59,7 @@ def test_color_controls():
 def test_controls_on_name(listener):
     color_mapper = bokeh.models.LinearColorMapper()
     controls = colors.ColorPalette(color_mapper)
-    controls.subscribe(listener)
+    controls.add_subscriber(listener)
     controls.on_number(None, None, 5)
     listener.assert_called_once_with(colors.set_palette_number(5))
 
@@ -130,7 +130,7 @@ def test_palette_numbers(name, expect):
 def test_controls_on_number(listener):
     color_mapper = bokeh.models.LinearColorMapper()
     controls = colors.ColorPalette(color_mapper)
-    controls.subscribe(listener)
+    controls.add_subscriber(listener)
     controls.on_number(None, None, 5)
     listener.assert_called_once_with(colors.set_palette_number(5))
 
@@ -138,7 +138,7 @@ def test_controls_on_number(listener):
 def test_controls_on_reverse(listener):
     color_mapper = bokeh.models.LinearColorMapper()
     controls = colors.ColorPalette(color_mapper)
-    controls.subscribe(listener)
+    controls.add_subscriber(listener)
     controls.on_reverse(None, None, [0])
     listener.assert_called_once_with(colors.set_reverse(True))
 
@@ -225,7 +225,7 @@ def test_user_limits_render():
 ])
 def test_user_limits_on_fixed(listener, new, action):
     user_limits = colors.UserLimits()
-    user_limits.subscribe(listener)
+    user_limits.add_subscriber(listener)
     user_limits.on_checkbox_change(None, None, new)
     listener.assert_called_once_with(action)
 
@@ -239,7 +239,7 @@ def test_user_limits_on_fixed(listener, new, action):
 ])
 def test_source_limits_on_change(listener, sources, low, high):
     source_limits = colors.SourceLimits(sources)
-    source_limits.subscribe(listener)
+    source_limits.add_subscriber(listener)
     source_limits.on_change(None, None, None)  # attr, old, new
     listener.assert_called_once_with(colors.set_source_limits(low, high))
 

--- a/test/test_db_control.py
+++ b/test/test_db_control.py
@@ -101,7 +101,7 @@ class TestControls(unittest.TestCase):
         value = "token"
         listener = unittest.mock.Mock()
         view = db.ControlView()
-        view.subscribe(listener)
+        view.add_subscriber(listener)
         view.on_change("variable")(None, None, value)
         listener.assert_called_once_with(db.set_value("variable", value))
 
@@ -114,7 +114,7 @@ class TestControls(unittest.TestCase):
                 db.next_previous,
                 db.Controls(self.database)])
         view = db.ControlView()
-        view.subscribe(store.dispatch)
+        view.add_subscriber(store.dispatch)
         view.on_next('pressure', 'pressures')()
         result = store.state
         expect = {
@@ -132,7 +132,7 @@ class TestControls(unittest.TestCase):
                 db.Controls(self.database)
             ])
         view = db.ControlView()
-        view.subscribe(store.dispatch)
+        view.add_subscriber(store.dispatch)
         view.on_next('pressure', 'pressures')()
         result = store.state
         expect = {}
@@ -153,7 +153,7 @@ class TestControls(unittest.TestCase):
                 db.Controls(self.database)
             ])
         view = db.ControlView()
-        view.subscribe(store.dispatch)
+        view.add_subscriber(store.dispatch)
         view.on_next('pressure', 'pressures')()
         result = store.state["pressure"]
         expect = 800
@@ -166,7 +166,7 @@ class TestControlView(unittest.TestCase):
 
     def test_on_click_emits_action(self):
         listener = unittest.mock.Mock()
-        self.view.subscribe(listener)
+        self.view.add_subscriber(listener)
         self.view.on_next("pressure", "pressures")()
         expect = db.next_value("pressure", "pressures")
         listener.assert_called_once_with(expect)
@@ -426,7 +426,7 @@ class TestStateStream(unittest.TestCase):
         old_states = (rx.Stream()
                   .listen_to(store)
                   .map(lambda x: db.State(**x)))
-        old_states.subscribe(listener)
+        old_states.add_subscriber(listener)
         store.dispatch(db.set_value("pressure", 1000))
         expect = db.State(pressure=1000)
         listener.assert_called_once_with(expect)

--- a/test/test_key_press.py
+++ b/test/test_key_press.py
@@ -6,7 +6,7 @@ def test_on_change_emits_action():
     code = 123
     listener = unittest.mock.Mock()
     key_press = forest.KeyPress()
-    key_press.subscribe(listener)
+    key_press.add_subscriber(listener)
     key_press.source.data = {'keys': [code]}
     action = forest.keys.press(code)
     listener.assert_called_once_with(action)

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -22,21 +22,21 @@ def listener():
 
 def test_figure_dropdown(listener):
     ui = layers.FigureUI()
-    ui.subscribe(listener)
+    ui.add_subscriber(listener)
     ui.on_change(None, None, ui.labels[0])
     listener.assert_called_once_with(layers.set_figures(1))
 
 
 def test_add(listener):
     ui = layers.LayersUI([])
-    ui.subscribe(listener)
+    ui.add_subscriber(listener)
     ui.on_click_add()
     listener.assert_called_once_with(layers.on_add())
 
 
 def test_remove(listener):
     ui = layers.LayersUI([])
-    ui.subscribe(listener)
+    ui.add_subscriber(listener)
     ui.on_click_remove()
     listener.assert_called_once_with(layers.on_remove())
 
@@ -117,7 +117,7 @@ def test_on_button_group(listener):
     row_index = 3
     attr, old, new = None, [], [2]
     controls = layers.LayersUI([])
-    controls.subscribe(listener)
+    controls.add_subscriber(listener)
     controls.on_button_group(row_index)(attr, old, new)
     listener.assert_called_once_with(layers.on_button_group(row_index, new))
 
@@ -126,7 +126,7 @@ def test_on_dropdown(listener):
     row_index = 3
     attr, old, new = None, None, "label"
     controls = layers.LayersUI([])
-    controls.subscribe(listener)
+    controls.add_subscriber(listener)
     controls.on_dropdown(row_index)(attr, old, new)
     listener.assert_called_once_with(layers.on_dropdown(row_index, new))
 

--- a/test/test_presets.py
+++ b/test/test_presets.py
@@ -121,7 +121,7 @@ def test_ui_actions(call_method, action):
     ui = presets.PresetUI()
     ui.select.value = "label"
     ui.text_input.value = "label"
-    ui.subscribe(listener)
+    ui.add_subscriber(listener)
     call_method(ui)
     listener.assert_called_once_with(action)
 

--- a/test/test_series.py
+++ b/test/test_series.py
@@ -40,7 +40,7 @@ def test_stream_distinct(values, expect):
     stream = rx.Stream()
     deduped = stream.distinct()
     listener = unittest.mock.Mock()
-    deduped.subscribe(listener)
+    deduped.add_subscriber(listener)
     for value in values:
         stream.notify(value)
     calls = [unittest.mock.call(v) for v in expect]
@@ -58,7 +58,7 @@ def test_stream_filter(values, predicate, expect):
     stream = rx.Stream()
     filtered = stream.filter(predicate)
     listener = unittest.mock.Mock()
-    filtered.subscribe(listener)
+    filtered.add_subscriber(listener)
     for value in values:
         stream.notify(value)
     calls = [unittest.mock.call(v) for v in expect]
@@ -121,7 +121,7 @@ def test_series_on_tap_emits_action():
     figure = bokeh.plotting.figure()
     event = bokeh.events.Tap(figure, x=x, y=y)
     view = series.SeriesView(figure, {})
-    view.subscribe(listener)
+    view.add_subscriber(listener)
     view.on_tap(event)
     listener.assert_called_once_with(series.set_position(x, y))
 


### PR DESCRIPTION
Closes #259 

This PR makes the code more readable. The current syntax, `foo.subscribe(bar)` is ambiguous. Does `foo` get notified by `bar` or is it the other way round?

The proposed change `foo.add_subscriber(bar)` makes it clear that `foo` will tell `bar` when it has something to announce