### PR TITLE
Argmax of a datetime64

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -25,7 +25,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 
 from .config import *
 from . import (

--- a/forest/satellite.py
+++ b/forest/satellite.py
@@ -12,6 +12,15 @@ from forest.util import coarsify
 from forest.exceptions import FileNotFound, IndexNotFound
 
 
+MIN_DATETIME64 = np.datetime64('0001-01-01T00:00:00.000000')
+
+
+def _natargmax(arr):
+    """ Find the arg max when an array contains NaT's"""
+    no_nats = np.where(np.isnat(arr), MIN_DATETIME64, arr)
+    return np.argmax(no_nats)
+
+
 class EIDA50(object):
     def __init__(self, pattern):
         self.locator = Locator(pattern)
@@ -86,7 +95,7 @@ class Locator(object):
             raise FileNotFound(msg)
         before_dates = np.ma.array(
                 dates, mask=mask, dtype='datetime64[s]')
-        return np.ma.argmax(before_dates)
+        return _natargmax(before_dates.filled())
 
     @staticmethod
     def find_index(times, time, length):
@@ -99,7 +108,7 @@ class Locator(object):
         if valid_times.mask.all():
             msg = "{}: not found".format(time)
             raise IndexNotFound(msg)
-        return np.ma.argmax(valid_times)
+        return _natargmax(valid_times.filled())
 
     @staticmethod
     def parse_date(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ intake
 intake-esm
 pygrib
 libwebp=1.0.2  # Pin to prevent Travis issue
-numpy=1.17.*
 xarray


### PR DESCRIPTION
Adapted `satellite.py` to calculate the argmax when an array of `np.datetime64`s contains `NaT` values. This is to solve the issue discovered in #275 

At the moment, numpy doesn't contain a `natargmax` function to mirror the functionality of [`np.nanargmax`](https://github.com/numpy/numpy/blob/maintenance/1.18.x/numpy/lib/nanfunctions.py#L510), so I wrote my own. I think it should work assuming that the array never contains satellite data from before the year 0 BC. There isn't an equivalent `-np.inf` for the datetime type at the moment as far as I can see.

I also bumped the version number and removed the numpy version pin.