### PR TITLE
Fix Stamen URLs

### DIFF
--- a/forest/components/tiles.py
+++ b/forest/components/tiles.py
@@ -16,7 +16,7 @@ WIKIMEDIA = "Wikimedia"
 URLS = {
     WIKIMEDIA: "https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}.png",
     OPEN_STREET_MAP: "http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png",
-    STAMEN_TERRAIN: "http://tile.stamen.com/terrain-background/{Z}/{X}/{Y}.jpg",
+    STAMEN_TERRAIN: "http://tile.stamen.com/terrain-background/{Z}/{X}/{Y}.png",
     STAMEN_WATERCOLOR: "http://tile.stamen.com/watercolor/{Z}/{X}/{Y}.jpg",
     STAMEN_TONER: "http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png",
     STAMEN_TONER_LITE: "http://tile.stamen.com/toner-lite/{Z}/{X}/{Y}.png"
@@ -32,7 +32,7 @@ def labels_url(name):
     """Tile server URL for labels"""
     default = "http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png"
     return {
-        STAMEN_TERRAIN: "http://tile.stamen.com/terrain-labels/{Z}/{X}/{Y}.jpg"
+        STAMEN_TERRAIN: "http://tile.stamen.com/terrain-labels/{Z}/{X}/{Y}.png"
     }.get(name, default)
 
 

--- a/test/test_components_tiles.py
+++ b/test/test_components_tiles.py
@@ -4,7 +4,7 @@ from forest.components import tiles
 
 @pytest.mark.parametrize("name,expect", [
     (tiles.OPEN_STREET_MAP, "http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png"),
-    (tiles.STAMEN_TERRAIN, "http://tile.stamen.com/terrain-background/{Z}/{X}/{Y}.jpg"),
+    (tiles.STAMEN_TERRAIN, "http://tile.stamen.com/terrain-background/{Z}/{X}/{Y}.png"),
     (tiles.STAMEN_WATERCOLOR, "http://tile.stamen.com/watercolor/{Z}/{X}/{Y}.jpg"),
     (tiles.STAMEN_TONER, "http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png"),
     (tiles.STAMEN_TONER_LITE, "http://tile.stamen.com/toner-lite/{Z}/{X}/{Y}.png"),
@@ -15,7 +15,7 @@ def test_background_url(name, expect):
 
 
 @pytest.mark.parametrize("name,expect", [
-    (tiles.STAMEN_TERRAIN, "http://tile.stamen.com/terrain-labels/{Z}/{X}/{Y}.jpg"),
+    (tiles.STAMEN_TERRAIN, "http://tile.stamen.com/terrain-labels/{Z}/{X}/{Y}.png"),
     (tiles.STAMEN_WATERCOLOR, "http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png"),
     (tiles.STAMEN_TONER, "http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png"),
     (tiles.STAMEN_TONER_LITE, "http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png"),


### PR DESCRIPTION
Avoids lots of unnecessary requests that only result in 301 Moved Permanently responses redirecting at the proper URLs.