### PR TITLE
Disable WMTS from config file

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -25,7 +25,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.9.2'
+__version__ = '0.10.0'
 
 from .config import *
 from . import (

--- a/forest/config.py
+++ b/forest/config.py
@@ -72,6 +72,18 @@ class Config(object):
         return "{}({})".format(
                 self.__class__.__name__,
                 self.data)
+    @property
+    def use_web_map_tiles(self):
+        """Turns web map tiling backgrounds on/off
+
+        .. code-block:: yaml
+
+            use_web_map_tiles: false
+
+        .. note:: This is best used during development if an internet
+                  connection is not available
+        """
+        return self.data.get("use_web_map_tiles", True)
 
     @property
     def default_viewport(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -199,3 +199,12 @@ def test_config_parser_given_json(tmpdir):
 def test_config_parser_presets_file(data, expect):
     config = forest.config.Config(data)
     assert config.presets_file == expect
+
+
+@pytest.mark.parametrize("data,expect", [
+    ({}, True),
+    ({"use_web_map_tiles": False}, False),
+])
+def test_config_parser_use_web_map_tiles(data, expect):
+    config = forest.config.Config(data)
+    assert config.use_web_map_tiles == expect


### PR DESCRIPTION
# Disable tiling services during development

Adds the following feature to the config file which is helpful for development with intermittent, expensive or no internet connection.

```yaml
use_web_map_tiles: false
```

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
