### PR TITLE
Remove line joined across dateline

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -25,7 +25,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.10.0'
+__version__ = '0.10.1'
 
 from .config import *
 from . import (

--- a/forest/data.py
+++ b/forest/data.py
@@ -95,11 +95,12 @@ def add_loader(name, loader):
 
 
 def load_coastlines():
-    return xs_ys(iterlines(
-            cartopy.feature.COASTLINE.geometries()))
+    return xs_ys(cut(iterlines(
+            cartopy.feature.COASTLINE.geometries()), 180))
 
 
 def xs_ys(lines):
+    """Map to Web Mercator projection and bokeh multi_line structure"""
     xs, ys = [], []
     for lons, lats in lines:
         x, y = geo.web_mercator(lons, lats)
@@ -111,7 +112,21 @@ def xs_ys(lines):
     }
 
 
+def cut(lines, x):
+    """Cut lines in two if they cross a vertical line"""
+    for line in lines:
+        xs, ys = line
+        xs, ys = np.ma.asarray(xs), np.ma.asarray(ys)
+        if (np.min(xs) < x) and (np.max(xs) > x):
+            pts = np.ma.asarray(xs) < x
+            yield xs[pts], ys[pts]
+            yield xs[~pts], ys[~pts]
+        else:
+            yield line
+
+
 def iterlines(geometries):
+    """Iterate lines from cartopy geometry"""
     def xy(g):
         if isinstance(g, shapely.geometry.LineString):
             return g.xy

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -4,6 +4,16 @@ from forest import (
         db)
 
 
+def test_cut():
+    lines = [[[0, 4, 6], [20, 30, 40]]]
+    result = list(data.cut(lines, x=5))
+    assert list(result[0][0]) == [0, 4]
+    assert list(result[0][1]) == [20, 30]
+    assert list(result[1][0]) == [6]
+    assert list(result[1][1]) == [40]
+
+
+
 class TestDBLoader(unittest.TestCase):
     def setUp(self):
         self.empty_image = {


### PR DESCRIPTION
# Remove line joined across dateline

Added a very simple `cut(lines, lon=180)` method to split the line wrapping the planet into two lines, one on either side of the dateline.

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
