### PR TITLE
Refactor old state

### DIFF
--- a/forest/earth_networks.py
+++ b/forest/earth_networks.py
@@ -5,6 +5,7 @@ import datetime as dt
 import pandas as pd
 from forest import geo
 from forest.gridded_forecast import _to_datetime
+from forest.old_state import old_state, unique
 import bokeh.models
 import bokeh.palettes
 import numpy as np
@@ -26,6 +27,8 @@ class View(object):
             "time_since_flash": []
         })
 
+    @old_state
+    @unique
     def render(self, state):
         valid_time = _to_datetime(state.valid_time)
         frame = self.loader.load_date(valid_time)

--- a/forest/layers.py
+++ b/forest/layers.py
@@ -11,6 +11,7 @@ import copy
 import bokeh.models
 import bokeh.layouts
 import numpy as np
+from collections import defaultdict
 from typing import Iterable, List
 from forest import rx
 from forest.redux import Action, State, Store
@@ -349,52 +350,29 @@ class LayersUI(Observable):
 
 
 class ViewerConnector:
-    """Connect Viewers that depend on old state to Store"""
-    def __init__(self, viewers, old_world):
-        self.viewers = viewers
-        self.old_world = old_world
-        self._previous = None
+    """Connect Views to Store"""
+    def __init__(self):
+        self.subscribers = defaultdict(list)
+
+    def add_label_subscriber(self, label, callback):
+        """Register views that depend on a label"""
+        self.subscribers[label].append(callback)
 
     def connect(self, store):
-        stream = (
-            rx.Stream()
-              .listen_to(store)
-              .map(self.to_props)
-              .filter(self.unique)
-        )
-        stream.map(lambda props: self.render(*props))
+        """Subscribe to all store dispatch events"""
+        store.add_subscriber(self.render)
         return self
 
-    def unique(self, props: tuple) -> bool:
-        """Check for duplicate labels, old_state events"""
-        if self._previous is None:
-            flag = True
-        else:
-            labels, state = props
-            previous_labels, previous_state = self._previous
-            if ((tuple(labels) == tuple(previous_labels)) and
-                    (state == previous_state)):
-                flag = False
-            else:
-                flag = True
-        self._previous = props
-        return flag
-
-    def to_props(self, state):
-        return (
-            self.layers(state),
-            self.old_world(state)
-        )
-
-    def layers(self, state):
-        return state.get("layers", {}).get("labels", [])
-
-    def render(self, labels, old_state):
-        """Send forest.db.State to each View.render"""
-        for label in labels:
+    def render(self, state):
+        """Notify listeners related to labels"""
+        for label in self.labels(state):
             if label is None:
                 continue
-            self.viewers[label].render(old_state)
+            for method in self.subscribers[label]:
+                method(state)
+
+    def labels(self, state):
+        return state.get("layers", {}).get("labels", [])
 
 
 class Artist:

--- a/forest/main.py
+++ b/forest/main.py
@@ -292,11 +292,10 @@ def main(argv=None):
     controls = db.ControlView()
     controls.connect(store)
 
-    def old_world(state):
-        kwargs = {k: state.get(k, None) for k in db.State._fields}
-        return db.State(**kwargs)
-
-    connector = layers.ViewerConnector(viewers, old_world).connect(store)
+    # Connect views to state changes
+    connector = layers.ViewerConnector().connect(store)
+    for label, viewer in viewers.items():
+        connector.add_label_subscriber(label, viewer.render)
 
     # Set default time series visibility
     store.dispatch(tools.on_toggle_tool("time_series", False))

--- a/forest/old_state.py
+++ b/forest/old_state.py
@@ -18,3 +18,29 @@ def old_state(f):
 def _to_old(state):
     kwargs = {k: state.get(k, None) for k in db.State._fields}
     return db.State(**kwargs)
+
+
+def unique(f):
+    previous = None
+    called = False
+
+    @wraps(f)
+    def wrapper(*args):
+        nonlocal previous
+        nonlocal called
+
+        if len(args) == 2:
+            self, value = args
+        else:
+            value, = args
+
+        if (not called) or (value != previous):
+            called = True
+            previous = value
+            if len(args) == 2:
+                result = f(self, value)
+            else:
+                result = f(value)
+            return result
+
+    return wrapper

--- a/forest/old_state.py
+++ b/forest/old_state.py
@@ -1,0 +1,20 @@
+"""Decorator to map dict to namedtuple state"""
+from functools import wraps
+from forest import db
+
+
+def old_state(f):
+    @wraps(f)
+    def wrapper(*args):
+        if len(args) == 2:
+            self, state = args
+            return f(self, _to_old(state))
+        else:
+            state, = args
+            return f(_to_old(state))
+    return wrapper
+
+
+def _to_old(state):
+    kwargs = {k: state.get(k, None) for k in db.State._fields}
+    return db.State(**kwargs)

--- a/forest/rdt.py
+++ b/forest/rdt.py
@@ -12,6 +12,7 @@ import numpy as np
 from forest import (
         geo,
         locate)
+from forest.old_state import old_state
 from forest.util import timeout_cache
 from forest.exceptions import FileNotFound
 from bokeh.palettes import GnBu3, OrRd3
@@ -126,6 +127,7 @@ class View(object):
         self.tail_point_source = bokeh.models.ColumnDataSource(self.empty_tail_point)
         self.centre_point_source = bokeh.models.ColumnDataSource(self.empty_centre_point)
 
+    @old_state
     def render(self, state):
         """Gets called when a menu button is clicked (or when application state changes)"""
         if state.valid_time is not None:

--- a/forest/rdt.py
+++ b/forest/rdt.py
@@ -12,7 +12,7 @@ import numpy as np
 from forest import (
         geo,
         locate)
-from forest.old_state import old_state
+from forest.old_state import old_state, unique
 from forest.util import timeout_cache
 from forest.exceptions import FileNotFound
 from bokeh.palettes import GnBu3, OrRd3
@@ -128,6 +128,7 @@ class View(object):
         self.centre_point_source = bokeh.models.ColumnDataSource(self.empty_centre_point)
 
     @old_state
+    @unique
     def render(self, state):
         """Gets called when a menu button is clicked (or when application state changes)"""
         if state.valid_time is not None:

--- a/forest/view.py
+++ b/forest/view.py
@@ -10,7 +10,7 @@ class UMView(object):
     def __init__(self, loader, color_mapper):
         self.loader = loader
         self.color_mapper = color_mapper
-        self.color_mapper.nan_color = bokeh.colors.RGB(0, 0, 0, a=0) 
+        self.color_mapper.nan_color = bokeh.colors.RGB(0, 0, 0, a=0)
         self.source = bokeh.models.ColumnDataSource({
                 "x": [],
                 "y": [],
@@ -79,6 +79,8 @@ class GPMView(object):
                 "image": []}
         self.source = bokeh.models.ColumnDataSource(self.empty)
 
+    @old_state
+    @unique
     def render(self, variable, pressure, itime):
         if variable != "precipitation_flux":
             self.source.data = self.empty
@@ -144,18 +146,21 @@ class EIDA50(object):
                 source=self.source,
                 color_mapper=self.color_mapper)
 
+
 class NearCast(object):
     def __init__(self, loader, color_mapper):
         self.loader = loader
         self.color_mapper = color_mapper
-        self.color_mapper.nan_color = bokeh.colors.RGB(0, 0, 0, a=0) 
+        self.color_mapper.nan_color = bokeh.colors.RGB(0, 0, 0, a=0)
         self.source = bokeh.models.ColumnDataSource({
                 "x": [],
                 "y": [],
                 "dw": [],
                 "dh": [],
                 "image": []})
-                
+
+    @old_state
+    @unique
     def render(self, state):
         self.source.data = self.loader.image(state)
 
@@ -177,6 +182,4 @@ class NearCast(object):
                tooltips=self.tooltips)
 
         figure.add_tools(tool)
-
         return renderer
-

--- a/forest/view.py
+++ b/forest/view.py
@@ -2,6 +2,7 @@ import datetime as dt
 import numpy as np
 import bokeh.models
 from forest import geo
+from forest.old_state import old_state, unique
 from forest.exceptions import FileNotFound, IndexNotFound
 
 
@@ -30,6 +31,8 @@ class UMView(object):
             'initial': 'datetime'
         }
 
+    @old_state
+    @unique
     def render(self, state):
         self.source.data = self.loader.image(state)
 
@@ -105,6 +108,8 @@ class EIDA50(object):
         self.source = bokeh.models.ColumnDataSource(
                 self.empty)
 
+    @old_state
+    @unique
     def render(self, state):
         if state.valid_time is not None:
             self.image(self.to_datetime(state.valid_time))


### PR DESCRIPTION
# Remove dependence on old namedtuple state

The purpose of this change is to break the connection between Viewers and old namedtuple states. This opens the door for more sophisticated viewers that use different parts of a richer state

- Replace mandatory dependence on `db.State` namedtuple for Image views with `@old_state` and `@unique` decorators.
- Simplify `ViewerConnector` to be a filter that updates subscribers if their label is in the current state

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
