### PR TITLE
Add support for feature toggles in yaml

### DIFF
--- a/doc/source/howto-feature-toggles.rst
+++ b/doc/source/howto-feature-toggles.rst
@@ -1,0 +1,25 @@
+
+Add a feature toggle
+--------------------
+
+It often happens that a feature is mostly done but not quite
+ready for a wider audience. Feature toggles give developers and
+user experience wizards the ability to test features early in
+the cycle and give them insight into performance and usability.
+
+
+.. code-block:: yaml
+
+   features:
+     foo: true
+     bar: false
+
+To access these settings in main.py use the following syntax.
+
+.. code-block:: python
+
+   if config.features['foo']:
+       # Do foo feature
+
+
+As easy as that.

--- a/doc/source/howto.rst
+++ b/doc/source/howto.rst
@@ -10,5 +10,6 @@ and tribulations associated with solving these problems.
 .. toctree::
    :maxdepth: 2
 
+   howto-feature-toggles
    howto-component
    howto-reducer

--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -25,7 +25,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.10.1'
+__version__ = '0.11.0'
 
 from .config import *
 from . import (

--- a/forest/config.py
+++ b/forest/config.py
@@ -23,6 +23,7 @@ applications.
 import os
 import string
 import yaml
+from collections import defaultdict
 from forest.export import export
 
 
@@ -72,6 +73,14 @@ class Config(object):
         return "{}({})".format(
                 self.__class__.__name__,
                 self.data)
+
+    @property
+    def features(self):
+        """Dict of user-defined feature toggles"""
+        d = defaultdict(lambda: True)
+        d.update(self.data.get("features", {}))
+        return d
+
     @property
     def use_web_map_tiles(self):
         """Turns web map tiling backgrounds on/off

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -214,6 +214,6 @@ def test_config_parser_use_web_map_tiles(data, expect):
     ({}, True),
     ({"features": {"example": False}}, False),
 ])
-def test_config_parser_true(data, expect):
+def test_config_parser_features(data, expect):
     config = forest.config.Config(data)
     assert config.features["example"] == expect

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -208,3 +208,12 @@ def test_config_parser_presets_file(data, expect):
 def test_config_parser_use_web_map_tiles(data, expect):
     config = forest.config.Config(data)
     assert config.use_web_map_tiles == expect
+
+
+@pytest.mark.parametrize("data,expect", [
+    ({}, True),
+    ({"features": {"example": False}}, False),
+])
+def test_config_parser_true(data, expect):
+    config = forest.config.Config(data)
+    assert config.features["example"] == expect


### PR DESCRIPTION
# Feature toggles

```yaml
features:
   foo: true
   bar: false
```

User configurable feature toggles from `--config-file` accessed as follows:

```python
if config.features['bar']:
   # Do bar stuff
```

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
