### PR TITLE
Add tools based on config.features contents

### DIFF
--- a/forest/main.py
+++ b/forest/main.py
@@ -257,7 +257,7 @@ def main(argv=None):
     layers_ui.connect(store)
 
     # Connect tools controls
-    tools_panel = tools.ToolsPanel()
+    tools_panel = tools.ToolsPanel(config.features)
     tools_panel.connect(store)
 
     # Connect tap listener

--- a/forest/main.py
+++ b/forest/main.py
@@ -348,7 +348,6 @@ def main(argv=None):
             child=bokeh.layouts.column(*layouts["settings"]),
             title="Settings")
         ])
-
     # Series sub-figure widget
     series_figure = bokeh.plotting.figure(
                 plot_width=400,
@@ -412,8 +411,7 @@ def main(argv=None):
     document.add_root(control_root)
     document.add_root(
         bokeh.layouts.column(
-            tools_panel.buttons["toggle_time_series"],
-            tools_panel.buttons["toggle_profile"],
+            tools_panel.layout,
             tool_layout.layout,
             width=400,
             name="series"))

--- a/forest/main.py
+++ b/forest/main.py
@@ -356,51 +356,58 @@ def main(argv=None):
             child=bokeh.layouts.column(*layouts["settings"]),
             title="Settings")
         ])
-    # Series sub-figure widget
-    series_figure = bokeh.plotting.figure(
-                plot_width=400,
-                plot_height=200,
-                x_axis_type="datetime",
-                toolbar_location=None,
-                border_fill_alpha=0)
-    series_figure.toolbar.logo = None
 
-    # Profile sub-figure widget
-    profile_figure = bokeh.plotting.figure(
-                plot_width=300,
-                plot_height=450,
-                toolbar_location=None,
-                border_fill_alpha=0)
-    profile_figure.toolbar.logo = None
-    profile_figure.y_range.flipped = True
+    tool_figures = {}
+    if config.features["time_series"]:
+        # Series sub-figure widget
+        series_figure = bokeh.plotting.figure(
+                    plot_width=400,
+                    plot_height=200,
+                    x_axis_type="datetime",
+                    toolbar_location=None,
+                    border_fill_alpha=0)
+        series_figure.toolbar.logo = None
 
-    tool_layout = tools.ToolLayout(series_figure, profile_figure)
+        series_view = series.SeriesView.from_groups(
+                series_figure,
+                config.file_groups)
+        series_view.add_subscriber(store.dispatch)
+        series_args = (rx.Stream()
+                    .listen_to(store)
+                    .map(series.select_args)
+                    .filter(lambda x: x is not None)
+                    .distinct())
+        series_args.map(lambda a: series_view.render(*a))
+        series_args.map(print)  # Note: map(print) creates None stream
+
+        tool_figures["series_figure"] = series_figure
+
+    if config.features["profile"]:
+        # Profile sub-figure widget
+        profile_figure = bokeh.plotting.figure(
+                    plot_width=300,
+                    plot_height=450,
+                    toolbar_location=None,
+                    border_fill_alpha=0)
+        profile_figure.toolbar.logo = None
+        profile_figure.y_range.flipped = True
+
+        profile_view = profile.ProfileView.from_groups(
+                profile_figure,
+                config.file_groups)
+        profile_view.add_subscriber(store.dispatch)
+        profile_args = (rx.Stream()
+                    .listen_to(store)
+                    .map(profile.select_args)
+                    .filter(lambda x: x is not None)
+                    .distinct())
+        profile_args.map(lambda a: profile_view.render(*a))
+        profile_args.map(print)  # Note: map(print) creates None stream
+
+        tool_figures["profile_figure"] = profile_figure
+
+    tool_layout = tools.ToolLayout(**tool_figures)
     tool_layout.connect(store)
-
-    series_view = series.SeriesView.from_groups(
-            series_figure,
-            config.file_groups)
-    series_view.add_subscriber(store.dispatch)
-    series_args = (rx.Stream()
-                .listen_to(store)
-                .map(series.select_args)
-                .filter(lambda x: x is not None)
-                .distinct())
-    series_args.map(lambda a: series_view.render(*a))
-    series_args.map(print)  # Note: map(print) creates None stream
-
-    profile_view = profile.ProfileView.from_groups(
-            profile_figure,
-            config.file_groups)
-    profile_view.add_subscriber(store.dispatch)
-    profile_args = (rx.Stream()
-                .listen_to(store)
-                .map(profile.select_args)
-                .filter(lambda x: x is not None)
-                .distinct())
-    profile_args.map(lambda a: profile_view.render(*a))
-    profile_args.map(print)  # Note: map(print) creates None stream
-
 
     for f in figures:
         f.on_event(bokeh.events.Tap, tap_listener.update_xy)

--- a/forest/main.py
+++ b/forest/main.py
@@ -257,7 +257,15 @@ def main(argv=None):
     layers_ui.connect(store)
 
     # Connect tools controls
-    tools_panel = tools.ToolsPanel(config.features)
+
+    display_names = {
+            "time_series": "Display Time Series",
+            "profile": "Display Profile"
+        }
+    available_features = {k: display_names[k]
+                          for k in display_names.keys() if config.features[k]}
+
+    tools_panel = tools.ToolsPanel(available_features)
     tools_panel.connect(store)
 
     # Connect tap listener

--- a/forest/tools.py
+++ b/forest/tools.py
@@ -63,10 +63,10 @@ class ToolsPanel(Observable):
         self.add_subscriber(store.dispatch)
         return self
 
-    def on_click(self, key):
+    def on_click(self, toggle_name):
         """update the store callback."""
         def callback(self, toggle_state):
-            self.notify(on_toggle_tool(key, toggle_state))
+            self.notify(on_toggle_tool(toggle_name, toggle_state))
 
         return callback
 

--- a/forest/tools.py
+++ b/forest/tools.py
@@ -42,12 +42,11 @@ def on_toggle_tool(tool_name, value) -> Action:
 
 class ToolsPanel(Observable):
     """ A panel that contains buttons to turn extra tools on and off"""
-    def __init__(self):
-        self.buttons = {
-            "toggle_time_series": bokeh.models.Toggle(label="Display Time Series"),
-            "toggle_profile": bokeh.models.Toggle(label="Display Profile")}
-        self.buttons["toggle_time_series"].on_click(self.on_click_time_series)
-        self.buttons["toggle_profile"].on_click(self.on_click_profile)
+    def __init__(self, key_to_name):
+        self.buttons = {}
+        for key, value in key_to_name.items():
+            self.buttons[key] = bokeh.models.Toggle(label=value)
+            self.buttons[key].on_click(self.on_click(key))
 
         self.layout = bokeh.layouts.column(*self.buttons.values())
         super().__init__()
@@ -56,13 +55,12 @@ class ToolsPanel(Observable):
         self.add_subscriber(store.dispatch)
         return self
 
-    def on_click_time_series(self, toggle_state):
-        """update the store."""
-        self.notify(on_toggle_tool("time_series", toggle_state))
+    def on_click(self, key):
+        """update the store callback."""
+        def callback(self, toggle_state):
+            self.notify(on_toggle_tool(key, toggle_state))
 
-    def on_click_profile(self, toggle_state):
-        """update the store."""
-        self.notify(on_toggle_tool("profile", toggle_state))
+        return callback
 
 class ToolLayout:
     """ Manage the row containing the tool plots """

--- a/forest/tools.py
+++ b/forest/tools.py
@@ -65,7 +65,7 @@ class ToolsPanel(Observable):
 
 class ToolLayout:
     """ Manage the row containing the tool plots """
-    def __init__(self, series_figure, profile_figure):
+    def __init__(self, series_figure=None, profile_figure=None):
         self.layout = bokeh.layouts.column()
         self.series_figure = series_figure
         self.profile_figure = profile_figure

--- a/forest/tools.py
+++ b/forest/tools.py
@@ -42,19 +42,12 @@ def on_toggle_tool(tool_name, value) -> Action:
 
 class ToolsPanel(Observable):
     """ A panel that contains buttons to turn extra tools on and off"""
-    def __init__(self, features):
-
-        features_to_buttons = {
-            "time_series": ("toggle_time_series", "Display Time Series"),
-            "profile": ("toggle_profile", "Display Profile")
-        }
+    def __init__(self, available_features):
 
         self.buttons = {}
-        for k, names in features_to_buttons.items():
-            if features[k]:
-                toggle_name, displayed_name = names
-                self.buttons[toggle_name] = bokeh.models.Toggle(label=displayed_name)
-                self.buttons[toggle_name].on_click(self.on_click(toggle_name))
+        for tool_name, display_name in available_features.items(): 
+            self.buttons[tool_name] = bokeh.models.Toggle(label=display_name)
+            self.buttons[tool_name].on_click(self.on_click(tool_name))
 
         self.layout = bokeh.layouts.column(*self.buttons.values())
         super().__init__()
@@ -65,7 +58,7 @@ class ToolsPanel(Observable):
 
     def on_click(self, toggle_name):
         """update the store callback."""
-        def callback(self, toggle_state):
+        def callback(toggle_state):
             self.notify(on_toggle_tool(toggle_name, toggle_state))
 
         return callback

--- a/forest/tools.py
+++ b/forest/tools.py
@@ -48,6 +48,8 @@ class ToolsPanel(Observable):
             "toggle_profile": bokeh.models.Toggle(label="Display Profile")}
         self.buttons["toggle_time_series"].on_click(self.on_click_time_series)
         self.buttons["toggle_profile"].on_click(self.on_click_profile)
+
+        self.layout = bokeh.layouts.column(*self.buttons.values())
         super().__init__()
 
     def connect(self, store):

--- a/forest/tools.py
+++ b/forest/tools.py
@@ -19,10 +19,10 @@ the components that depend on state changes
 """
 
 import copy
-from forest.observe import Observable
-from forest.redux import Action, State
 import bokeh.layouts
 import bokeh.models
+from forest.observe import Observable
+from forest.redux import Action, State
 
 ON_TOGGLE_TOOL = "TOGGLE_TOOL_VISIBILITY"
 
@@ -42,11 +42,19 @@ def on_toggle_tool(tool_name, value) -> Action:
 
 class ToolsPanel(Observable):
     """ A panel that contains buttons to turn extra tools on and off"""
-    def __init__(self, key_to_name):
+    def __init__(self, features):
+
+        features_to_buttons = {
+            "time_series": ("toggle_time_series", "Display Time Series"),
+            "profile": ("toggle_profile", "Display Profile")
+        }
+
         self.buttons = {}
-        for key, value in key_to_name.items():
-            self.buttons[key] = bokeh.models.Toggle(label=value)
-            self.buttons[key].on_click(self.on_click(key))
+        for k, names in features_to_buttons.items():
+            if features[k]:
+                toggle_name, displayed_name = names
+                self.buttons[toggle_name] = bokeh.models.Toggle(label=displayed_name)
+                self.buttons[toggle_name].on_click(self.on_click(toggle_name))
 
         self.layout = bokeh.layouts.column(*self.buttons.values())
         super().__init__()

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -6,28 +6,28 @@ import bokeh
 from forest import tools, db, redux
 
 def test_tool_toggle_reducer():
-    state = tools.reducer({}, tools.on_toggle_tool("toggle_time_series", True))
-    assert state == {"tools": {"toggle_time_series": True}}
+    state = tools.reducer({}, tools.on_toggle_tool("time_series", True))
+    assert state == {"tools": {"time_series": True}}
 
 def test_tool_toggle_reducer_immutable_state():
-    state = {"tools": {"toggle_time_series": True}}
+    state = {"tools": {"time_series": True}}
     next_state = tools.reducer(
-        state, 
-        tools.on_toggle_tool("toggle_time_series", False)
+        state,
+        tools.on_toggle_tool("time_series", False)
         )
-    assert state == {"tools": {"toggle_time_series": True}}
-    assert next_state == {"tools": {"toggle_time_series": False}}
+    assert state == {"tools": {"time_series": True}}
+    assert next_state == {"tools": {"time_series": False}}
 
 @pytest.mark.parametrize("actions,expect", [
     ([], {}),
-    ([tools.on_toggle_tool("toggle_profile", False)], 
-     {"tools": {"toggle_profile": False}}),
+    ([tools.on_toggle_tool("profile", False)],
+     {"tools": {"profile": False}}),
     ([db.set_value("key", "value")], {"key": "value"}),
     ([
-        tools.on_toggle_tool("toggle_time_series", False),
+        tools.on_toggle_tool("time_series", False),
         db.set_value("key", "value")], {
             "key": "value",
-            "tools": {"toggle_time_series": False}}),
+            "tools": {"time_series": False}}),
 ])
 def test_combine_reducers(actions, expect):
     reducer = redux.combine_reducers(tools.reducer, db.reducer)
@@ -37,19 +37,13 @@ def test_combine_reducers(actions, expect):
     assert state == expect
 
 def test_tools_on_toggle_tool_action():
-    action = tools.on_toggle_tool("toggle_time_series", False)
+    action = tools.on_toggle_tool("time_series", False)
     assert action == {"kind": tools.ON_TOGGLE_TOOL, 
-                      "tool_name": "toggle_time_series", "value": False}
+                      "tool_name": "time_series", "value": False}
 
-def test_tools_panel_on_toggling_tool_emits_action():
+def test_tools_panel_on_toggle_emits_action():
     listener = unittest.mock.Mock()
-    features = defaultdict(lambda: False)
-    features["time_series"] = True
-    tools_panel = tools.ToolsPanel(features)
+    tools_panel = tools.ToolsPanel({"time_series": "wheeeyyyy"})
     tools_panel.add_subscriber(listener)
-    #For reasons I don't understand, this doesn't trigger a toggle event
-    tools_panel.buttons["toggle_time_series"].active = True
-    listener.assert_called_once_with(
-        tools.on_toggle_tool("toggle_time_series", False)
-    )
-
+    tools_panel.on_click("time_series")(True)
+    listener.assert_called_once_with(tools.on_toggle_tool("time_series", True))

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,0 +1,55 @@
+from collections import defaultdict
+import pytest
+import unittest
+import unittest.mock
+import bokeh
+from forest import tools, db, redux
+
+def test_tool_toggle_reducer():
+    state = tools.reducer({}, tools.on_toggle_tool("toggle_time_series", True))
+    assert state == {"tools": {"toggle_time_series": True}}
+
+def test_tool_toggle_reducer_immutable_state():
+    state = {"tools": {"toggle_time_series": True}}
+    next_state = tools.reducer(
+        state, 
+        tools.on_toggle_tool("toggle_time_series", False)
+        )
+    assert state == {"tools": {"toggle_time_series": True}}
+    assert next_state == {"tools": {"toggle_time_series": False}}
+
+@pytest.mark.parametrize("actions,expect", [
+    ([], {}),
+    ([tools.on_toggle_tool("toggle_profile", False)], 
+     {"tools": {"toggle_profile": False}}),
+    ([db.set_value("key", "value")], {"key": "value"}),
+    ([
+        tools.on_toggle_tool("toggle_time_series", False),
+        db.set_value("key", "value")], {
+            "key": "value",
+            "tools": {"toggle_time_series": False}}),
+])
+def test_combine_reducers(actions, expect):
+    reducer = redux.combine_reducers(tools.reducer, db.reducer)
+    state = {}
+    for action in actions:
+        state = reducer(state, action)
+    assert state == expect
+
+def test_tools_on_toggle_tool_action():
+    action = tools.on_toggle_tool("toggle_time_series", False)
+    assert action == {"kind": tools.ON_TOGGLE_TOOL, 
+                      "tool_name": "toggle_time_series", "value": False}
+
+def test_tools_panel_on_toggling_tool_emits_action():
+    listener = unittest.mock.Mock()
+    features = defaultdict(lambda: False)
+    features["time_series"] = True
+    tools_panel = tools.ToolsPanel(features)
+    tools_panel.add_subscriber(listener)
+    #For reasons I don't understand, this doesn't trigger a toggle event
+    tools_panel.buttons["toggle_time_series"].active = True
+    listener.assert_called_once_with(
+        tools.on_toggle_tool("toggle_time_series", False)
+    )
+


### PR DESCRIPTION

The profile and time series figures are currently very IO heavy. We want to be able to configure forest to disable the profile and time series figures in the production deployment while we improve the performance.

## Check list

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
