### PR TITLE
Convert HTML to Bokeh Buttons

### DIFF
--- a/forest/main.py
+++ b/forest/main.py
@@ -403,6 +403,31 @@ def main(argv=None):
             tabs,
             name="controls")
 
+    buttons = {}
+
+    # Add button to control left drawer
+    key = "sidenav_button"
+    buttons[key] = bokeh.models.Button(
+        label="Settings",
+        name=key)
+    custom_js = bokeh.models.CustomJS(code="""
+        openId("sidenav");
+    """)
+    buttons[key].js_on_click(custom_js)
+
+    # Add button to control right drawer
+    key = "diagrams_button"
+    buttons[key] = bokeh.models.Button(
+        label="Diagrams",
+        css_classes=["float-right"],
+        name=key)
+    custom_js = bokeh.models.CustomJS(code="""
+        openId("diagrams");
+    """)
+    buttons[key].js_on_click(custom_js)
+
+    headline.layout.name = "headline"
+
     # Add key press support
     key_press = keys.KeyPress()
     key_press.add_subscriber(store.dispatch)
@@ -419,9 +444,9 @@ def main(argv=None):
             name="series"))
     document.add_root(
         bokeh.layouts.row(time_ui.layout, name="time"))
-    document.add_root(
-        bokeh.layouts.column(headline.layout, name="headline",
-                          sizing_mode="stretch_width"))
+    document.add_root(buttons["sidenav_button"])
+    document.add_root(headline.layout)
+    document.add_root(buttons["diagrams_button"])
     document.add_root(
         bokeh.layouts.row(colorbar_ui.layout, name="colorbar"))
     document.add_root(figure_row.layout)

--- a/forest/static/style.css
+++ b/forest/static/style.css
@@ -85,11 +85,17 @@ footer {
 .display-none {
     display: none;
 }
+.display-inline-block {
+    display: inline-block;
+}
 .float-left {
     float: left;
 }
 .float-right {
     float: right;
+}
+.margin-left-110 {
+    margin-left: 110px;
 }
 
 

--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -15,11 +15,15 @@
     </div>
 
     <nav>
-        <button class="float-left" type="button" onclick="openId('sidenav')">Settings</button>
-        <div class="float-left headline-container">
+        <div class="display-inline-block float-left">
+        {{ embed(roots.sidenav_button) | indent(10) }}
+        </div>
+        <div class="margin-left-110 display-inline-block float-left">
         {{ embed(roots.headline) | indent(10) }}
         </div>
-        <button type="button" class="float-right" onclick="openId('diagrams')">Diagrams</button>
+        <div class="float-right">
+        {{ embed(roots.diagrams_button) | indent(10) }}
+        </div>
     </nav>
 
     <!-- Layout figure row -->


### PR DESCRIPTION
# Bokeh should manage the diagrams drawer button

Convert from vanilla HTML to using Bokeh widgets to control drawers.

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
