### PR TITLE
Patch template to remove diagrams button

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -25,7 +25,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.12.1'
+__version__ = '0.12.2'
 
 from .config import *
 from . import (

--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -21,11 +21,17 @@
         <div class="margin-left-110 display-inline-block float-left">
         {{ embed(roots.headline) | indent(10) }}
         </div>
-        {% if roots.diagrams_button %}
-            <div class="float-right">
-            {{ embed(roots.diagrams_button) | indent(10) }}
-            </div>
-        {% endif %}
+        <!-- Embed optional button -->
+        {% for root in roots %}
+            <!-- Note: roots.attname raises ValueError if attname not found
+                       see bokeh.embed.util.RenderRoots.__getitem__
+            -->
+            {% if root.name == 'diagrams_button' %}
+                <div class="float-right">
+                {{ embed(roots.diagrams_button) | indent(10) }}
+                </div>
+            {% endif %}
+        {% endfor %}
     </nav>
 
     <!-- Layout figure row -->


### PR DESCRIPTION
# Fix ValueError in jinja2 template

Bokeh converts document.add_root objects into  `bokeh.embed.RenderRoots` objects before passing it on to Jinja2. The `__getitem__` method raises a ValueError if a root name is not available. This makes the syntax neat but difficult to optionally include roots at runtime.

This fix while lacking unit tests to cover the bug does solve the issue.

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
