### PR TITLE
Fix nearcast variables

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -25,7 +25,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.12.4'
+__version__ = '0.12.5'
 
 from .config import *
 from . import (

--- a/forest/nearcast.py
+++ b/forest/nearcast.py
@@ -98,7 +98,7 @@ class Navigator:
         paths = self.locator.find(self.pattern)
         if len(paths) == 0:
             return []
-        return list(sorted(self._variables(paths[-1])))
+        return list(sorted(set(self._variables(paths[-1]))))
 
     @staticmethod
     def _variables(path):

--- a/test/test_drivers_nearcast.py
+++ b/test/test_drivers_nearcast.py
@@ -1,0 +1,28 @@
+import pytest
+import unittest.mock
+import pygrib
+from forest import nearcast
+
+
+def make_open(names):
+    # Simulate pygrib.open(path).select() -> messages
+    def _open(path):
+        messages = unittest.mock.Mock()
+        messages.select.return_value = [
+            {"name": name} for name in names
+        ]
+        return messages
+    return _open
+
+
+@pytest.mark.parametrize("names,expect", [
+    (["A", "A", "A"], ["A"]),
+    (["D", "C", "B", "A"], ["A", "B", "C", "D"]),
+])
+def test_navigator_variables(monkeypatch, names, expect):
+    pattern = ""
+    navigator = nearcast.Navigator(pattern)
+    navigator.locator = unittest.mock.Mock()
+    navigator.locator.find.return_value = ["some.grib"]
+    monkeypatch.setattr(pygrib, "open", make_open(names))
+    assert navigator.variables(pattern) == expect


### PR DESCRIPTION
# Remove duplicates from variable menu

Add `set` operation to nearcast navigator

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
