### PR TITLE
Move GHRSST support closer to driver pattern

### DIFF
--- a/forest/drivers/earth_networks.py
+++ b/forest/drivers/earth_networks.py
@@ -13,7 +13,7 @@ import numpy as np
 
 class Dataset:
     """High-level class to relate navigators, loaders and views"""
-    def __init__(self, pattern=None):
+    def __init__(self, pattern=None, **kwargs):
         self.pattern = pattern
         if pattern is not None:
             self._paths = glob.glob(pattern)

--- a/forest/drivers/ghrsstl4.py
+++ b/forest/drivers/ghrsstl4.py
@@ -64,8 +64,6 @@ def coordinates(valid_time, initial_time, pressures, pressure):
         'length': [length],
         'level': [level]
     }
-
-
 def _is_valid_cube(cube):
     """Return True if, and only if, the cube conforms to a GHRSST data specification"""
     attributes = cube.metadata.attributes
@@ -105,7 +103,8 @@ def _load(pattern):
 
 class Dataset:
     """High-level class to relate navigators, loaders and views"""
-    def __init__(self, pattern=None, color_mapper=None, **kwargs):
+    def __init__(self, label=None, pattern=None, color_mapper=None, **kwargs):
+        self._label = label
         self.pattern = pattern
         self.color_mapper = color_mapper
         if pattern is not None:
@@ -119,10 +118,11 @@ class Dataset:
 
     def map_view(self):
         """Construct view"""
-        return UMView(ImageLoader(self._paths), self.color_mapper)
+        return UMView(ImageLoader(self._label, self._paths), self.color_mapper)
 
 class ImageLoader:
-    def __init__(self, pattern):
+    def __init__(self, label, pattern):
+        self._label = label
         self._cubes = _load(pattern)
 
     def image(self, state):
@@ -138,6 +138,7 @@ class ImageLoader:
             data.update(coordinates(state.valid_time, state.initial_time,
                                     state.pressures, state.pressure))
             data.update({
+                'name': [self._label],
                 'units': [str(cube.units)]
             })
         return data

--- a/forest/load.py
+++ b/forest/load.py
@@ -32,7 +32,6 @@ from forest import (
         intake_loader,
         saf,
         nearcast)
-from forest.drivers import ghrsstl4
 
 
 __all__ = []
@@ -138,8 +137,6 @@ class Loader(object):
             return satellite.EIDA50(pattern)
         elif file_type == 'griddedforecast':
             return gridded_forecast.ImageLoader(label, pattern)
-        elif file_type == 'ghrsstl4':
-            return ghrsstl4.ImageLoader(label, pattern)
         elif file_type == 'unifiedmodel':
             return data.DBLoader(label, pattern, locator)
         elif file_type == 'intake':

--- a/forest/main.py
+++ b/forest/main.py
@@ -127,6 +127,7 @@ def main(argv=None):
         else:
             # Use dataset interface
             settings = {
+                "label": group.label,
                 "pattern": group.pattern,
                 "color_mapper": color_mapper
             }

--- a/forest/main.py
+++ b/forest/main.py
@@ -127,7 +127,8 @@ def main(argv=None):
         else:
             # Use dataset interface
             settings = {
-                "pattern": group.pattern
+                "pattern": group.pattern,
+                "color_mapper": color_mapper
             }
             dataset = drivers.get_dataset(group.file_type, settings)
             viewer = dataset.map_view()

--- a/forest/navigate.py
+++ b/forest/navigate.py
@@ -18,9 +18,6 @@ from forest import (
         saf,
         nearcast)
 
-from forest.drivers import (
-    ghrsstl4)
-
 
 class Navigator:
     def __init__(self, config):
@@ -100,8 +97,6 @@ class FileSystemNavigator:
             return gridded_forecast.Navigator(paths)
         elif file_type.lower() == 'intake':
             return intake_loader.Navigator()
-        elif file_type.lower() == 'ghrsstl4':
-            return ghrsstl4.Navigator(paths)
         elif file_type.lower() == "unified_model":
             coordinates = unified_model.Coordinates()
         elif file_type.lower() == "saf":

--- a/test/test_drivers.py
+++ b/test/test_drivers.py
@@ -1,8 +1,9 @@
+import pytest
 from forest import drivers
 
 
-def test_singleton_dataset():
-    driver_name = "earth_networks"
+@pytest.mark.parametrize("driver_name", ["earth_networks", "ghrsstl4"])
+def test_singleton_dataset(driver_name):
     datasets = (
         drivers.get_dataset(driver_name),
         drivers.get_dataset(driver_name))

--- a/test/test_ghrsstl4.py
+++ b/test/test_ghrsstl4.py
@@ -155,9 +155,8 @@ class Test_ImageLoader(unittest.TestCase):
     @patch('forest.drivers.ghrsstl4._load')
     def test_init(self, load):
         load.return_value = sentinel.cubes
-        result = ghrsstl4.ImageLoader(sentinel.label, sentinel.pattern)
+        result = ghrsstl4.ImageLoader(sentinel.pattern)
         load.assert_called_once_with(sentinel.pattern)
-        self.assertEqual(result._label, sentinel.label)
         self.assertEqual(result._cubes, sentinel.cubes)
 
     @patch('forest.drivers.ghrsstl4.empty_image')
@@ -216,7 +215,7 @@ class Test_ImageLoader(unittest.TestCase):
                                             sentinel.pressures,
                                             sentinel.pressure)
         self.assertEqual(result, {'stretched_image': True, 'coordinates': True,
-                                  'name': ['my-label'], 'units': ['my-units']})
+                                  'units': ['my-units']})
 
 
 class Test_Navigator(unittest.TestCase):

--- a/test/test_ghrsstl4.py
+++ b/test/test_ghrsstl4.py
@@ -155,8 +155,9 @@ class Test_ImageLoader(unittest.TestCase):
     @patch('forest.drivers.ghrsstl4._load')
     def test_init(self, load):
         load.return_value = sentinel.cubes
-        result = ghrsstl4.ImageLoader(sentinel.pattern)
+        result = ghrsstl4.ImageLoader(sentinel.label, sentinel.pattern)
         load.assert_called_once_with(sentinel.pattern)
+        self.assertEqual(result._label, sentinel.label)
         self.assertEqual(result._cubes, sentinel.cubes)
 
     @patch('forest.drivers.ghrsstl4.empty_image')
@@ -215,7 +216,7 @@ class Test_ImageLoader(unittest.TestCase):
                                             sentinel.pressures,
                                             sentinel.pressure)
         self.assertEqual(result, {'stretched_image': True, 'coordinates': True,
-                                  'units': ['my-units']})
+                                  'name': ['my-label'], 'units': ['my-units']})
 
 
 class Test_Navigator(unittest.TestCase):

--- a/test/test_navigator.py
+++ b/test/test_navigator.py
@@ -174,17 +174,6 @@ def test_FileSystemNavigator_from_file_type__griddedforecast(navigator_cls):
     assert navigator == sentinel.navigator
 
 
-@patch('forest.drivers.ghrsstl4.Navigator')
-def test_FileSystemNavigator_from_file_type__ghrsstl4(navigator_cls):
-    navigator_cls.return_value = sentinel.navigator
-
-    navigator = navigate.FileSystemNavigator.from_file_type(sentinel.paths,
-                                                            'ghrssTL4')
-
-    navigator_cls.assert_called_once_with(sentinel.paths)
-    assert navigator == sentinel.navigator
-
-
 @patch('forest.unified_model.Coordinates')
 def test_FileSystemNavigator_from_file_type__unified_model(coordinates_cls):
     coordinates_cls.return_value = sentinel.coordinates


### PR DESCRIPTION
# Refactor of GHRSST to new driver pattern

In the spirit of #299, I added a Dataset class to `drivers/ghrsstl4.py` and `color_mapper` support for the drivers.

I am not quite convinced that this is what you had in mind with the settings dictionary in `main.py`, so let me know what you think things ought to be different.

I want to invest some time in migrating the ghrsstl4 tests to pytest and tidying things up a bit more, but I thought I would check the direction I am going in is OK before going further.

## Check list

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
