### PR TITLE
Add cftime 1.1.1 support

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -25,7 +25,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.13.0'
+__version__ = '0.13.1'
 
 from .config import *
 from . import (

--- a/forest/gridded_forecast.py
+++ b/forest/gridded_forecast.py
@@ -35,6 +35,8 @@ def _to_datetime(d):
         return d
     if isinstance(d, cftime.DatetimeNoLeap):
         return datetime(d.year, d.month, d.day, d.hour, d.minute, d.second)
+    elif isinstance(d, cftime.DatetimeGregorian):
+        return datetime(d.year, d.month, d.day, d.hour, d.minute, d.second)
     elif isinstance(d, str):
         try:
             return datetime.strptime(d, "%Y-%m-%d %H:%M:%S")

--- a/forest/series.py
+++ b/forest/series.py
@@ -335,5 +335,9 @@ class SeriesLocator(object):
 
     __getitem__ = locate
 
-    def key(self, time):
-        return "{:%Y-%m-%d %H:%M:%S}".format(time)
+    @staticmethod
+    def key(time):
+        try:
+            return "{:%Y-%m-%d %H:%M:%S}".format(time)
+        except TypeError:
+            return time.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_gridded_forecast.py
+++ b/test/test_gridded_forecast.py
@@ -1,3 +1,5 @@
+import pytest
+import cftime
 from datetime import datetime
 from unittest.mock import Mock, call, patch, sentinel
 import unittest
@@ -18,24 +20,29 @@ class Test_empty_image(unittest.TestCase):
             self.assertEqual(value, [])
 
 
+@pytest.mark.parametrize("given,expect", [
+    pytest.param('2019-10-10 01:02:34',
+                 datetime(2019, 10, 10, 1, 2, 34),
+                 id="str with space"),
+    pytest.param('2019-10-10T01:02:34',
+                 datetime(2019, 10, 10, 1, 2, 34),
+                 id="iso8601"),
+    pytest.param(np.datetime64('2019-10-10T11:22:33'),
+                 datetime(2019, 10, 10, 11, 22, 33),
+                 id="datetime64"),
+    pytest.param(cftime.DatetimeGregorian(2019, 10, 10, 11, 22, 33),
+                 datetime(2019, 10, 10, 11, 22, 33),
+                 id="cftime.DatetimeGregorian"),
+])
+def test__to_datetime(given, expect):
+    assert gridded_forecast._to_datetime(given) == expect
+
+
 class Test_to_datetime(unittest.TestCase):
     def test_datetime(self):
         dt = datetime.now()
         result = gridded_forecast._to_datetime(dt)
         self.assertEqual(result, dt)
-
-    def test_str_with_space(self):
-        result = gridded_forecast._to_datetime('2019-10-10 01:02:34')
-        self.assertEqual(result, datetime(2019, 10, 10, 1, 2, 34))
-
-    def test_str_iso8601(self):
-        result = gridded_forecast._to_datetime('2019-10-10T01:02:34')
-        self.assertEqual(result, datetime(2019, 10, 10, 1, 2, 34))
-
-    def test_datetime64(self):
-        dt = np.datetime64('2019-10-10T11:22:33')
-        result = gridded_forecast._to_datetime(dt)
-        self.assertEqual(result, datetime(2019, 10, 10, 11, 22, 33))
 
     def test_unsupported(self):
         with self.assertRaisesRegex(Exception, 'Unknown value'):

--- a/test/test_series.py
+++ b/test/test_series.py
@@ -2,6 +2,7 @@ import pytest
 import unittest
 import os
 import netCDF4
+import cftime
 import numpy as np
 import numpy.testing as npt
 import datetime as dt
@@ -318,6 +319,14 @@ def test_4d_variable(tmpdir):
     }
     npt.assert_array_equal(expect["x"], result["x"])
     npt.assert_array_equal(expect["y"], result["y"])
+
+
+@pytest.mark.parametrize("value,expect", [
+    (dt.datetime(2020, 1, 1), "2020-01-01 00:00:00"),
+    (cftime.DatetimeGregorian(2020, 1, 1), "2020-01-01 00:00:00")
+])
+def test_series_locator_key(value, expect):
+    assert series.SeriesLocator.key(value) == expect
 
 
 class TestSeries(unittest.TestCase):


### PR DESCRIPTION
# cftime 1.1.1

The latest release of `cftime` returns `cftime.DatetimeGregorian` instead of standard lib `datetime.datetime` objects

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
