### PR TITLE
Migrate gridded_forecast to forest.drivers

### DIFF
--- a/forest/_profile.py
+++ b/forest/_profile.py
@@ -53,7 +53,7 @@ from forest import geo
 from forest.observe import Observable
 from forest.redux import Action
 from forest.util import initial_time as _initial_time
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 from forest.screen import SET_POSITION
 try:
     import iris

--- a/forest/components/time.py
+++ b/forest/components/time.py
@@ -1,7 +1,7 @@
 """Time navigation component"""
 from forest import rx
 from forest.observe import Observable
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 import forest.db.control
 import bokeh.plotting
 import numpy as np

--- a/forest/data.py
+++ b/forest/data.py
@@ -17,7 +17,6 @@ except ImportError:
     # ReadTheDocs unable to pip install cf-units
     pass
 from forest import (
-        gridded_forecast,
         geo,
         disk)
 import bokeh.models

--- a/forest/db/control.py
+++ b/forest/db/control.py
@@ -7,7 +7,7 @@ import bokeh.layouts
 from . import util
 from collections import namedtuple
 from forest.observe import Observable
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 from forest.export import export
 from typing import List, Any
 

--- a/forest/drivers/earth_networks.py
+++ b/forest/drivers/earth_networks.py
@@ -4,7 +4,7 @@ import glob
 import datetime as dt
 import pandas as pd
 from forest import geo
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 from forest.old_state import old_state, unique
 import bokeh.models
 import bokeh.palettes

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from forest.exceptions import FileNotFound, IndexNotFound
 from forest.old_state import old_state, unique
 from forest.util import coarsify
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 from forest import (
         geo,
         locate,

--- a/forest/drivers/gridded_forecast.py
+++ b/forest/drivers/gridded_forecast.py
@@ -10,7 +10,9 @@ except ModuleNotFoundError:
 
 import cftime
 
+import glob
 from forest import geo
+from forest.view import UMView
 
 
 def empty_image():
@@ -104,6 +106,25 @@ def _load(pattern):
         cube_mapping[name] = cube
     return cube_mapping
 
+
+class Dataset:
+    """High-level class to relate navigators, loaders and views"""
+    def __init__(self, label=None, pattern=None, color_mapper=None, **kwargs):
+        self._label = label
+        self.pattern = pattern
+        self.color_mapper = color_mapper
+        if pattern is not None:
+            self._paths = glob.glob(pattern)
+        else:
+            self._paths = []
+
+    def navigator(self):
+        """Construct navigator"""
+        return Navigator(self._paths)
+
+    def map_view(self):
+        """Construct view"""
+        return UMView(ImageLoader(self._label, self._paths), self.color_mapper)
 
 class ImageLoader:
     def __init__(self, label, pattern):

--- a/forest/drivers/saf.py
+++ b/forest/drivers/saf.py
@@ -19,7 +19,7 @@ import glob
 import re
 import os
 import netCDF4
-from forest.gridded_forecast import empty_image, coordinates
+from forest.drivers.gridded_forecast import empty_image, coordinates
 from forest.util import timeout_cache
 from forest import geo, view
 from functools import lru_cache

--- a/forest/drivers/unified_model.py
+++ b/forest/drivers/unified_model.py
@@ -8,10 +8,10 @@ import netCDF4
 from forest import (
     db,
     disk,
-    gridded_forecast,
     view)
 from forest.data import load_image_pts
 from forest.exceptions import SearchFail, PressuresNotFound
+from forest.drivers import gridded_forecast 
 try:
     import iris
 except ImportError:

--- a/forest/intake_loader.py
+++ b/forest/intake_loader.py
@@ -18,7 +18,8 @@ try:
 except ModuleNotFoundError:
     intake = None
 
-from forest import geo, gridded_forecast
+from forest import geo
+from forest.drivers import gridded_forecast
 
 # Location of the Pangeo-CMIP6 intake catalogue file.
 URL = 'https://raw.githubusercontent.com/NCAR/intake-esm-datastore/master/catalogs/pangeo-cmip6.json'

--- a/forest/load.py
+++ b/forest/load.py
@@ -24,10 +24,11 @@ from forest.export import export
 from forest import (
         exceptions,
         data,
-        gridded_forecast,
         rdt,
         intake_loader,
         nearcast)
+
+from forest.drivers import gridded_forecast
 
 
 __all__ = []

--- a/forest/navigate.py
+++ b/forest/navigate.py
@@ -10,10 +10,10 @@ from forest import (
         exceptions,
         drivers,
         db,
-        gridded_forecast,
         rdt,
         intake_loader,
         nearcast)
+from forest.drivers import gridded_forecast
 
 
 class Navigator:

--- a/forest/nearcast.py
+++ b/forest/nearcast.py
@@ -9,7 +9,7 @@ import datetime as dt
 import numpy as np
 from forest import geo
 from forest.util import timeout_cache
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 
 try:
     import pygrib as pg

--- a/forest/rdt.py
+++ b/forest/rdt.py
@@ -18,7 +18,7 @@ from forest.exceptions import FileNotFound
 from bokeh.palettes import GnBu3, OrRd3
 import itertools
 import math
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 
 
 class RenderGroup(object):

--- a/forest/series.py
+++ b/forest/series.py
@@ -39,7 +39,7 @@ from forest import geo
 from forest.observe import Observable
 from forest.redux import Action
 from forest.util import initial_time as _initial_time
-from forest.gridded_forecast import _to_datetime
+from forest.drivers.gridded_forecast import _to_datetime
 from forest.screen import SET_POSITION
 
 try:

--- a/test/test_gridded_forecast.py
+++ b/test/test_gridded_forecast.py
@@ -7,7 +7,7 @@ import unittest
 import iris
 import numpy as np
 
-from forest import gridded_forecast
+from forest.drivers import gridded_forecast
 
 
 class Test_empty_image(unittest.TestCase):
@@ -49,7 +49,7 @@ class Test_to_datetime(unittest.TestCase):
             gridded_forecast._to_datetime(12)
 
 
-@patch('forest.gridded_forecast._to_datetime')
+@patch('forest.drivers.gridded_forecast._to_datetime')
 class Test_coordinates(unittest.TestCase):
     def test_surface_and_times(self, to_datetime):
         valid = datetime(2019, 10, 10, 9)
@@ -132,7 +132,7 @@ class Test_is_valid_cube(unittest.TestCase):
 
 
 class Test_load(unittest.TestCase):
-    @patch('forest.gridded_forecast._is_valid_cube')
+    @patch('forest.drivers.gridded_forecast._is_valid_cube')
     @patch('iris.load')
     def test_all_unique(self, load, is_valid_cube):
         cube1 = Mock(**{'name.return_value': 'foo'})
@@ -146,7 +146,7 @@ class Test_load(unittest.TestCase):
         self.assertEqual(is_valid_cube.mock_calls, [call(cube1), call(cube2)])
         self.assertEqual(result, {'foo': cube1, 'bar': cube2})
 
-    @patch('forest.gridded_forecast._is_valid_cube')
+    @patch('forest.drivers.gridded_forecast._is_valid_cube')
     @patch('iris.load')
     def test_duplicate_name(self, load, is_valid_cube):
         cube1 = Mock(**{'name.return_value': 'foo'})
@@ -160,7 +160,7 @@ class Test_load(unittest.TestCase):
         self.assertEqual(is_valid_cube.mock_calls, [call(cube1), call(cube2)])
         self.assertEqual(result, {'foo (1)': cube1, 'foo (2)': cube2})
 
-    @patch('forest.gridded_forecast._is_valid_cube')
+    @patch('forest.drivers.gridded_forecast._is_valid_cube')
     @patch('iris.load')
     def test_none_valid(self, load, is_valid_cube):
         load.return_value = ['foo', 'bar']
@@ -171,7 +171,7 @@ class Test_load(unittest.TestCase):
 
 
 class Test_ImageLoader(unittest.TestCase):
-    @patch('forest.gridded_forecast._load')
+    @patch('forest.drivers.gridded_forecast._load')
     def test_init(self, load):
         load.return_value = sentinel.cubes
         result = gridded_forecast.ImageLoader(sentinel.label, sentinel.pattern)
@@ -179,9 +179,9 @@ class Test_ImageLoader(unittest.TestCase):
         self.assertEqual(result._label, sentinel.label)
         self.assertEqual(result._cubes, sentinel.cubes)
 
-    @patch('forest.gridded_forecast.empty_image')
+    @patch('forest.drivers.gridded_forecast.empty_image')
     @patch('iris.Constraint')
-    @patch('forest.gridded_forecast._to_datetime')
+    @patch('forest.drivers.gridded_forecast._to_datetime')
     def test_empty(self, to_datetime, constraint, empty_image):
         # To avoid re-testing the constructor, just make a fake ImageLoader
         # instance.
@@ -201,10 +201,10 @@ class Test_ImageLoader(unittest.TestCase):
         original_cube.extract.assert_called_once_with(sentinel.constraint)
         self.assertEqual(result, sentinel.empty_image)
 
-    @patch('forest.gridded_forecast.coordinates')
+    @patch('forest.drivers.gridded_forecast.coordinates')
     @patch('forest.geo.stretch_image')
     @patch('iris.Constraint')
-    @patch('forest.gridded_forecast._to_datetime')
+    @patch('forest.drivers.gridded_forecast._to_datetime')
     def test_image(self, to_datetime, constraint, stretch_image, coordinates):
         # To avoid re-testing the constructor, just make a fake ImageLoader
         # instance.
@@ -239,7 +239,7 @@ class Test_ImageLoader(unittest.TestCase):
 
 
 class Test_Navigator(unittest.TestCase):
-    @patch('forest.gridded_forecast._load')
+    @patch('forest.drivers.gridded_forecast._load')
     def test_init(self, load):
         load.return_value = sentinel.cubes
         result = gridded_forecast.Navigator(sentinel.paths)

--- a/test/test_navigator.py
+++ b/test/test_navigator.py
@@ -131,7 +131,7 @@ def test_FileSystemNavigator_from_file_type__rdt(coordinates_cls):
     assert navigator.coordinates == sentinel.coordinates
 
 
-@patch('forest.gridded_forecast.Navigator')
+@patch('forest.drivers.gridded_forecast.Navigator')
 def test_FileSystemNavigator_from_file_type__griddedforecast(navigator_cls):
     navigator_cls.return_value = sentinel.navigator
 


### PR DESCRIPTION
# Migrate gridded_forecast to forest.drivers

Simple move of gridded_forecast.py. Probably worth in the future moving `to_datetime` and `empty_image` to `util.py`, since they are used in a number of places, and even redefined in `ghrsstl4.py`. This can wait for the next PR.

No change in functionality, so no need to bump version.
