### PR TITLE
Add test for NaN handling

### DIFF
--- a/test/test_datashader.py
+++ b/test/test_datashader.py
@@ -7,6 +7,7 @@ from forest import geo
 try:
     import datashader
     import xarray
+    from bokeh.core.json_encoder import serialize_json
     libs_available = True
 except ModuleNotFoundError:
     libs_available = False
@@ -46,3 +47,41 @@ def test_datashader_stretch_image():
     result = geo.datashader_stretch(z, x, y, x_range, y_range)
     expect = z
     numpy.testing.assert_array_equal(result, expect)
+
+@pytest.mark.skipif(not libs_available,
+                    reason='datashader and xarray are optional')
+def test_datashader_image_nan():
+    '''Test the datashader image stretch function works correctly 
+    if the inputs 2D arraysi containing NaNs in both coordinates and 
+    values.
+    
+    Tests the modification made in commit 05962ec'''
+    x = numpy.array(
+      [[ numpy.nan,  numpy.nan,  numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [ numpy.nan,  numpy.nan,  numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [ numpy.nan,  numpy.nan,  numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [-32.12598 , -32.07721 , -32.02848 , numpy.nan, numpy.nan, numpy.nan],
+       [-32.15292 , -32.104084, -32.055298, numpy.nan, numpy.nan, numpy.nan],
+       [-32.17996 , -32.13106 , -32.08221 , numpy.nan, numpy.nan, numpy.nan]])
+    y = numpy.array(
+      [[ numpy.nan,  numpy.nan,  numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [ numpy.nan,  numpy.nan,  numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [ numpy.nan,  numpy.nan,  numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [-40.60027 , -40.596905, -40.593544, numpy.nan, numpy.nan, numpy.nan],
+       [-40.643642, -40.640266, -40.636898, numpy.nan, numpy.nan, numpy.nan],
+       [-40.68706 , -40.683674, -40.680298, numpy.nan, numpy.nan, numpy.nan]])
+    z = numpy.array(
+      [[ numpy.nan, numpy.nan, numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [ numpy.nan, numpy.nan, numpy.nan, numpy.nan, numpy.nan, numpy.nan],
+       [ 276.23   , 273.04   , 270.75   , numpy.nan, numpy.nan, numpy.nan],
+       [ 277.12   , 273.55   , 270.82   , numpy.nan, numpy.nan, numpy.nan],
+       [ numpy.nan, 273.24   , 270.16998, numpy.nan, numpy.nan, numpy.nan],
+       [ numpy.nan, numpy.nan, numpy.nan, numpy.nan, numpy.nan, numpy.nan]])
+
+    result = geo.stretch_image(x, y, z)
+
+    #this will fail on a ValueError if the NaNs above are handled improperly
+    serialize_json(result)
+
+    #Should be returning NumPy masked arrays
+    assert numpy.ma.is_masked(result['image'][0])


### PR DESCRIPTION
## NaN Handling test

Unit test to check that NaNs on incoming SAF data are correctly handled during `stretch_image`; mostly tests `forest/geo.py` but AFAIK only affects SAF data. (basically tests commit 05962ec )

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
