### PR TITLE
Refactor Navigators

### DIFF
--- a/forest/main.py
+++ b/forest/main.py
@@ -78,6 +78,7 @@ def main(argv=None):
     # Colorbar user interface
     colorbar_ui = forest.components.ColorbarUI(color_mapper)
 
+    datasets = {}
     renderers = {}
     viewers = {}
     for group in config.file_groups:
@@ -90,6 +91,7 @@ def main(argv=None):
             "color_mapper": color_mapper,
         }
         dataset = drivers.get_dataset(group.file_type, settings)
+        datasets[group.pattern] = dataset
         viewer = dataset.map_view()
         viewers[group.label] = viewer
         renderers[group.label] = [
@@ -181,7 +183,8 @@ def main(argv=None):
         bokeh.layouts.column(dropdown))
 
 
-    navigator = navigate.Navigator(config, color_mapper=color_mapper)
+    navigator = navigate.Navigator({key: dataset.navigator()
+                                    for key, dataset in datasets.items()})
 
     # Pre-select menu choices (if any)
     initial_state = {}

--- a/forest/navigate.py
+++ b/forest/navigate.py
@@ -1,32 +1,12 @@
-from forest import drivers
 
 
 class Navigator:
-    def __init__(self, config, color_mapper=None):
-        # TODO: Once the idea of a "Group" exists we can avoid using the
-        # config and defer the sub-navigator creation to each of the
-        # groups. This will remove the need for the `_from_group` helper
-        # and the logic in FileSystemNavigator.from_file_type().
-        # Also, it'd be good to switch the identification of groups from
-        # using the `pattern` to using the `label`. In general, not every
-        # group would have a `pattern`.
-        # e.g.
-        # self._navigators = {group.label: group.navigator for group in ...}
-        self._navigators = {group.pattern: self._from_group(group, color_mapper)
-                           for group in config.file_groups}
+    """High-level Navigator
 
-    @classmethod
-    def _from_group(cls, group, color_mapper=None):
-        settings = {
-            "label": group.label,
-            "pattern": group.pattern,
-            "locator": group.locator,
-            "database_path": group.database_path,
-            "directory": group.directory,
-            "color_mapper": color_mapper,
-        }
-        dataset = drivers.get_dataset(group.file_type, settings)
-        return dataset.navigator()
+    :param navigators: dict of sub-navigators distinguished by pattern
+    """
+    def __init__(self, _navigators):
+        self._navigators = _navigators
 
     def variables(self, pattern):
         navigator = self._navigators[pattern]

--- a/forest/navigate.py
+++ b/forest/navigate.py
@@ -6,6 +6,11 @@ class Navigator:
     :param navigators: dict of sub-navigators distinguished by pattern
     """
     def __init__(self, _navigators):
+        # TODO: It'd be good to switch the identification of navigators from
+        # using the `pattern` to using the `label`. In general, not every
+        # group would have a `pattern`.
+        # e.g.
+        # self._navigators = {label: navigator for label, navigator in ...}
         self._navigators = _navigators
 
     def variables(self, pattern):

--- a/test/test_navigator.py
+++ b/test/test_navigator.py
@@ -15,22 +15,6 @@ def test_get_database_with_real_dependencies(tmpdir):
         forest.db.get_database(database_path)
 
 
-@patch('forest.navigate.Navigator._from_group')
-def test_Navigator_init(from_group):
-    from_group.side_effect = [sentinel.nav1, sentinel.nav2]
-    group1 = Mock(pattern='pattern1')
-    group2 = Mock(pattern='pattern2')
-    config = Mock(file_groups=[group1, group2])
-
-    navigator = navigate.Navigator(config)
-
-    color_mapper = None
-    assert from_group.mock_calls == [call(group1, color_mapper),
-                                     call(group2, color_mapper)]
-    assert navigator._navigators == {'pattern1': sentinel.nav1,
-                                     'pattern2': sentinel.nav2}
-
-
 def test_Navigator_variables():
     sub_navigator = Mock()
     sub_navigator.variables.return_value = sentinel.variables


### PR DESCRIPTION
# Simplify navigators to use datasets API

Navigators is a middleman that forwards messages to sub-navigators it no longer needs knowledge of the config, groups or indeed dataset constructors

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
