### PR TITLE
Optimize EIDA50

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.13.4'
+__version__ = '0.13.5'
 
 from .config import *
 from . import (

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -26,20 +26,6 @@ def _natargmax(arr):
     return np.argmax(no_nats)
 
 
-def infinite_cache(f):
-    """Unbounded cache to reduce navigation I/O
-
-    .. note:: This information would be better saved in a database
-              or file to reduce round-trips to disk
-    """
-    cache = {}
-    def wrapped(self, path):
-        if path not in cache:
-            cache[path] = f(self, path)
-        return cache[path]
-    return wrapped
-
-
 class Dataset:
     def __init__(self, pattern=None, color_mapper=None, **kwargs):
         self.pattern = pattern

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -8,8 +8,7 @@ import numpy as np
 from functools import lru_cache
 from forest.exceptions import FileNotFound, IndexNotFound
 from forest.old_state import old_state, unique
-from forest.util import coarsify
-from forest.util import to_datetime as _to_datetime
+import forest.util
 from forest import (
         geo,
         locate,
@@ -44,6 +43,7 @@ class Locator:
     """Locate EIDA50 satellite images"""
     def __init__(self, pattern):
         self.pattern = pattern
+        self._glob = forest.util.cached_glob(dt.timedelta(minutes=15))
 
     def find(self, date):
         if isinstance(date, (dt.datetime, str)):
@@ -59,7 +59,7 @@ class Locator:
         return path, index
 
     def glob(self):
-        return sorted(glob.glob(os.path.expanduser(self.pattern)))
+        return self._glob(self.pattern)
 
     @staticmethod
     @lru_cache()
@@ -136,7 +136,7 @@ class Loader:
             data = self.empty_image
         else:
             try:
-                data = self._image(_to_datetime(state.valid_time))
+                data = self._image(forest.util.to_datetime(state.valid_time))
             except (FileNotFound, IndexNotFound):
                 data = self.empty_image
         return data

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -150,11 +150,13 @@ class Loader:
         lats = self.latitudes
         with xarray.open_dataset(path, engine=ENGINE) as nc:
             values = nc["data"][itime].values
-        fraction = 0.25
-        lons, lats, values = coarsify(
-                lons, lats, values, fraction)
+
+        # Use datashader to coarsify images from 4.4km to 8.8km grid
+        scale = 2
         return geo.stretch_image(
-                lons, lats, values)
+                lons, lats, values,
+                plot_width=int(values.shape[1] / scale),
+                plot_height=int(values.shape[0] / scale))
 
 
 class Navigator:

--- a/forest/drivers/saf.py
+++ b/forest/drivers/saf.py
@@ -91,12 +91,6 @@ class Loader:
         return data
 
 
-@forest.util.timeout_cache(dt.timedelta(minutes=10))
-def cached_glob(pattern):
-    """Glob file system at most once every 10 minutes for a pattern"""
-    return sorted(glob.glob(pattern))
-
-
 class Locator:
     """Locate SAF files"""
     def __init__(self, pattern):
@@ -104,10 +98,11 @@ class Locator:
         regex = "[0-9]{8}T[0-9]{6}Z"
         fmt = "%Y%m%dT%H%M%S%Z"
         self.parse_date = partial(forest.util.parse_date, regex, fmt)
+        self._glob = forest.util.cached_glob(dt.timedelta(minutes=10))
 
     def glob(self):
         """List file system"""
-        return cached_glob(self.pattern)
+        return self._glob(self.pattern)
 
     def find_paths(self, paths, date, frequency):
         """Find a file(s) containing information related to date"""

--- a/forest/util.py
+++ b/forest/util.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import re
 import datetime as dt
@@ -33,6 +34,21 @@ def timeout_cache(interval):
                     return cache[x]
         return wrapped
     return decorator
+
+
+_timeout_globs = {}
+
+
+def cached_glob(interval):
+    """Glob file system at most once every interval"""
+    global _timeout_globs
+    if interval not in _timeout_globs:
+        _timeout_globs[interval] = timeout_cache(interval)(_glob)
+    return _timeout_globs[interval]
+
+
+def _glob(pattern):
+    return sorted(glob.glob(os.path.expanduser(pattern)))
 
 
 def coarsify(lons, lats, values, fraction):

--- a/test/test_drivers_eida50.py
+++ b/test/test_drivers_eida50.py
@@ -167,18 +167,6 @@ def test_locator_find_index_outside_range_raises_exception():
         eida50.Locator.find_index(times, time, freq)
 
 
-def test_navigator_valid_times_given_toa_brightness_temperature(tmpdir):
-    path = str(tmpdir / "test-navigate-eida50.nc")
-    times = [dt.datetime(2019, 1, 1)]
-    with netCDF4.Dataset(path, "w") as dataset:
-        _eida50(dataset, times)
-
-    navigator = eida50.Navigator(path)
-    result = navigator._valid_times(path)
-    expect = times
-    assert expect == result
-
-
 def test_loader_image(tmpdir):
     path = str(tmpdir / "file_20190417.nc")
     with netCDF4.Dataset(path, "w") as dataset:

--- a/test/test_drivers_eida50.py
+++ b/test/test_drivers_eida50.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import Mock
 import datetime as dt
 import bokeh.models
 import netCDF4
@@ -72,10 +73,19 @@ def test_navigator_pressures():
     assert navigator.pressures(None, None, None) == []
 
 
-def test_locator_parse_date():
-    path = "/some/file-20190101.nc"
+@pytest.mark.parametrize("path,expect", [
+    pytest.param("/some/file-20190101.nc",
+                 dt.datetime(2019, 1, 1),
+                 id="yyyymmdd format"),
+    pytest.param("/some/file-20190101T1245Z.nc",
+                 dt.datetime(2019, 1, 1, 12, 45),
+                 id="yyyymmdd hm format"),
+    pytest.param("eida50.nc",
+                 None,
+                 id="no timestamp"),
+])
+def test_locator_parse_date(path, expect):
     result = eida50.Locator.parse_date(path)
-    expect = dt.datetime(2019, 1, 1)
     assert expect == result
 
 
@@ -164,7 +174,7 @@ def test_navigator_valid_times_given_toa_brightness_temperature(tmpdir):
         _eida50(dataset, times)
 
     navigator = eida50.Navigator(path)
-    result = navigator._valid_times(path, "toa_brightness_temperature")
+    result = navigator._valid_times(path)
     expect = times
     assert expect == result
 
@@ -178,13 +188,6 @@ def test_loader_image(tmpdir):
     image = loader._image(time)
     result = set(image.keys())
     expect = set(["x", "y", "dw", "dh", "image"])
-    assert expect == result
-
-
-def test_locator_parse_date():
-    path = "/some/EIDA50_takm4p4_20190417.nc"
-    result = eida50.Locator.parse_date(path)
-    expect = dt.datetime(2019, 4, 17)
     assert expect == result
 
 
@@ -244,3 +247,12 @@ def test_navigator_valid_times(tmpdir):
     result = navigator.valid_times(path, variable, TIMES[0])
     expect = TIMES
     np.testing.assert_array_equal(expect, result)
+
+
+def test_navigator_given_valid_time_none_returns_parsed_times():
+    paths = ["eida50_20200101.nc"]
+    dataset = forest.drivers.get_dataset("eida50")
+    navigator = dataset.navigator()
+    result = navigator.valid_times_from_paths(paths)
+    assert result == [dt.datetime(2020, 1, 1)]
+


### PR DESCRIPTION
# Optimize EIDA50

Quick fixes to make EIDA50 super-fast and stable
- [x] Faster navigation by parsing file names
- [x] Better memory by using h5netcdf xarray driver
- [x] Higher resolution 8.8km instead of 17.6km (e.g. 4.4km * 4) since finding/loading data is so fast
- [x] Cached glob to reduce S3 meta-data queries

**Note:** Memory usage was not an issue, iterating through 100's of files only increased the resting memory by less than a megabyte. But consistency is important for later code additions

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
