### PR TITLE
Optimize EIDA50 metadata search

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.13.5'
+__version__ = '0.13.6'
 
 from .config import *
 from . import (

--- a/forest/drivers/ghrsstl4.py
+++ b/forest/drivers/ghrsstl4.py
@@ -90,10 +90,9 @@ def _load(pattern):
 
 class Dataset:
     """High-level class to relate navigators, loaders and views"""
-    def __init__(self, label=None, pattern=None, color_mapper=None, **kwargs):
+    def __init__(self, label=None, pattern=None, **kwargs):
         self._label = label
         self.pattern = pattern
-        self.color_mapper = color_mapper
         if pattern is not None:
             self._paths = glob.glob(pattern)
         else:
@@ -103,9 +102,9 @@ class Dataset:
         """Construct navigator"""
         return Navigator(self._paths)
 
-    def map_view(self):
+    def map_view(self, color_mapper):
         """Construct view"""
-        return UMView(ImageLoader(self._label, self._paths), self.color_mapper)
+        return UMView(ImageLoader(self._label, self._paths), color_mapper)
 
 class ImageLoader:
     def __init__(self, label, pattern):

--- a/forest/drivers/gpm.py
+++ b/forest/drivers/gpm.py
@@ -19,18 +19,17 @@ def read_times(path):
 
 
 class Dataset:
-    def __init__(self, pattern=None, color_mapper=None, **kwargs):
+    def __init__(self, pattern=None, **kwargs):
         self.pattern = pattern
         self.locator = Locator()
-        self.color_mapper = color_mapper
 
     def navigator(self):
         return Navigator(self.pattern, self.locator)
 
-    def map_view(self):
+    def map_view(self, color_mapper):
         return forest.view.UMView(_Loader(self.pattern,
                                           self.locator),
-                                  self.color_mapper,
+                                  color_mapper,
                                   use_hover_tool=False)
 
 

--- a/forest/drivers/gridded_forecast.py
+++ b/forest/drivers/gridded_forecast.py
@@ -91,10 +91,9 @@ def _load(pattern):
 
 class Dataset:
     """High-level class to relate navigators, loaders and views"""
-    def __init__(self, label=None, pattern=None, color_mapper=None, **kwargs):
+    def __init__(self, label=None, pattern=None, **kwargs):
         self._label = label
         self.pattern = pattern
-        self.color_mapper = color_mapper
         if pattern is not None:
             self._paths = glob.glob(pattern)
         else:
@@ -104,9 +103,9 @@ class Dataset:
         """Construct navigator"""
         return Navigator(self._paths)
 
-    def map_view(self):
+    def map_view(self, color_mapper):
         """Construct view"""
-        return UMView(ImageLoader(self._label, self._paths), self.color_mapper)
+        return UMView(ImageLoader(self._label, self._paths), color_mapper)
 
 class ImageLoader:
     def __init__(self, label, pattern):

--- a/forest/drivers/intake_loader.py
+++ b/forest/drivers/intake_loader.py
@@ -27,16 +27,15 @@ URL = 'https://raw.githubusercontent.com/NCAR/intake-esm-datastore/master/catalo
 
 
 class Dataset:
-    def __init__(self, pattern=None, color_mapper=None, **kwargs):
+    def __init__(self, pattern=None, **kwargs):
         self.pattern = pattern
-        self.color_mapper = color_mapper
 
     def navigator(self):
         return Navigator()
 
-    def map_view(self):
+    def map_view(self, color_mapper):
         loader = IntakeLoader(self.pattern)
-        view = forest.view.UMView(loader, self.color_mapper)
+        view = forest.view.UMView(loader, color_mapper)
         view.set_hover_properties(INTAKE_TOOLTIPS, INTAKE_FORMATTERS)
         return view
 

--- a/forest/drivers/nearcast.py
+++ b/forest/drivers/nearcast.py
@@ -24,15 +24,14 @@ NEARCAST_TOOLTIPS = [("Name", "@name"),
 
 
 class Dataset:
-    def __init__(self, pattern=None, color_mapper=None, **kwargs):
+    def __init__(self, pattern=None, **kwargs):
         self.pattern = pattern
-        self.color_mapper = color_mapper
 
     def navigator(self):
         return Navigator(self.pattern)
 
-    def map_view(self):
-        view = forest.view.NearCast(NearCast(self.pattern), self.color_mapper)
+    def map_view(self, color_mapper):
+        view = forest.view.NearCast(NearCast(self.pattern), color_mapper)
         view.set_hover_properties(NEARCAST_TOOLTIPS)
         return view
 

--- a/forest/drivers/saf.py
+++ b/forest/drivers/saf.py
@@ -33,21 +33,19 @@ class Dataset:
                  label=None,
                  pattern=None,
                  locator=None,
-                 database_path=None,
-                 color_mapper=None):
+                 database_path=None):
         self.label = label
         self.pattern = pattern
-        self.color_mapper = color_mapper
         self.locator = Locator(self.pattern)
 
     def navigator(self):
         """Construct navigator"""
         return Navigator(self.locator)
 
-    def map_view(self):
+    def map_view(self, color_mapper):
         """Construct view"""
         loader = Loader(self.locator, self.label)
-        return view.UMView(loader, self.color_mapper)
+        return view.UMView(loader, color_mapper)
 
 
 class Loader:

--- a/forest/drivers/unified_model.py
+++ b/forest/drivers/unified_model.py
@@ -30,14 +30,12 @@ class Dataset:
     def __init__(self,
                  label=None,
                  pattern=None,
-                 color_mapper=None,
                  locator="file_system",
                  directory=None,
                  database_path=None,
                  **kwargs):
         self.label = label
         self.pattern = pattern
-        self.color_mapper = color_mapper
         self.use_database = locator == "database"
         if self.use_database:
             self.database = db.get_database(database_path)
@@ -52,10 +50,10 @@ class Dataset:
         else:
             return Navigator(self.pattern)
 
-    def map_view(self):
+    def map_view(self, color_mapper):
         return view.UMView(Loader(self.label,
                                   self.pattern,
-                                  self.locator), self.color_mapper)
+                                  self.locator), color_mapper)
 
 
 class Navigator:

--- a/forest/main.py
+++ b/forest/main.py
@@ -205,12 +205,13 @@ def main(argv=None):
         keys.navigate,
         db.InverseCoordinate("pressure"),
         db.next_previous,
-        db.Controls(navigator),
+        db.Controls(navigator),  # TODO: Deprecate this middleware
         colors.palettes,
         colors.middleware(),
         presets.Middleware(presets.proxy_storage(config.presets_file)),
         presets.middleware,
         layers.middleware,
+        navigator,
     ]
     store = redux.Store(
         redux.combine_reducers(

--- a/forest/main.py
+++ b/forest/main.py
@@ -87,15 +87,17 @@ def main(argv=None):
             "pattern": group.pattern,
             "locator": group.locator,
             "database_path": group.database_path,
-            "directory": group.directory,
-            "color_mapper": color_mapper,
+            "directory": group.directory
         }
         dataset = drivers.get_dataset(group.file_type, settings)
         datasets[group.pattern] = dataset
 
         # Add optional map view
         if hasattr(dataset, "map_view"):
-            map_view = dataset.map_view()
+            try:
+                map_view = dataset.map_view(color_mapper)
+            except TypeError:
+                map_view = dataset.map_view()
             map_views[group.label] = map_view
             renderers[group.label] = [
                     map_view.add_figure(f)

--- a/forest/navigate.py
+++ b/forest/navigate.py
@@ -13,6 +13,16 @@ class Navigator:
         # self._navigators = {label: navigator for label, navigator in ...}
         self._navigators = _navigators
 
+    def __call__(self, store, action):
+        """Pass through to appropriate sub-navigator"""
+        pattern = store.state.get("pattern")
+        if pattern is not None:
+            try:
+                yield from self._navigators[pattern](store, action)
+            except TypeError:
+                # Sub-navigator not callable
+                pass
+
     def variables(self, pattern):
         navigator = self._navigators[pattern]
         return navigator.variables(pattern)

--- a/test/test_drivers_eida50.py
+++ b/test/test_drivers_eida50.py
@@ -237,10 +237,28 @@ def test_navigator_valid_times(tmpdir):
     np.testing.assert_array_equal(expect, result)
 
 
-def test_navigator_given_valid_time_none_returns_parsed_times():
+def test_navigator_parse_times_from_file_names():
     paths = ["eida50_20200101.nc"]
     dataset = forest.drivers.get_dataset("eida50")
     navigator = dataset.navigator()
-    result = navigator.valid_times_from_paths(paths)
+    result = navigator.locator.valid_times_from_paths(paths)
     assert result == [dt.datetime(2020, 1, 1)]
 
+
+def test_database():
+    path = "file.nc"
+    times = [dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 2)]
+    database = forest.drivers.eida50.Database()
+    database.insert_times(times[:1], path)
+    database.insert_times(times[1:], path)
+    assert database.fetch_times() == times
+    assert database.fetch_paths() == [path]
+
+
+def test_database_open_twice(tmpdir):
+    """sqlite3.OperationalError if table not robust to redefinition"""
+    path = str(tmpdir / "file.db")
+    with forest.drivers.eida50.Database(path):
+        pass
+    with forest.drivers.eida50.Database(path):
+        pass

--- a/test/test_drivers_eida50.py
+++ b/test/test_drivers_eida50.py
@@ -70,7 +70,7 @@ def test_dataset_map_view():
 
 
 def test_navigator_pressures():
-    navigator = eida50.Navigator(None)
+    navigator = eida50.Navigator(None, None)
     assert navigator.pressures(None, None, None) == []
 
 

--- a/test/test_drivers_eida50.py
+++ b/test/test_drivers_eida50.py
@@ -95,7 +95,7 @@ def test_locator_find_given_no_files_raises_notfound(tmpdir):
     pattern = str(tmpdir / "nofile.nc")
     locator = eida50.Locator(pattern, eida50.Database())
     with pytest.raises(FileNotFound):
-        locator.find(any_date)
+        locator.find([], any_date)
 
 
 def test_locator_find_given_a_single_file(tmpdir):
@@ -108,7 +108,8 @@ def test_locator_find_given_a_single_file(tmpdir):
         set_times(dataset, times)
 
     locator = eida50.Locator(pattern, eida50.Database())
-    found_path, index = locator.find(valid_date)
+    paths = locator.glob()
+    found_path, index = locator.find(paths, valid_date)
     assert found_path == path
     assert index == 0
 
@@ -125,7 +126,8 @@ def test_find_given_multiple_files(tmpdir):
             set_times(dataset, [date])
     valid_date = dt.datetime(2019, 1, 2, 0, 14)
     locator = eida50.Locator(pattern, eida50.Database())
-    found_path, index = locator.find(valid_date)
+    paths = locator.glob()
+    found_path, index = locator.find(paths, valid_date)
     expect = str(tmpdir / "test-eida50-20190102.nc")
     assert found_path == expect
     assert index == 0

--- a/test/test_drivers_eida50.py
+++ b/test/test_drivers_eida50.py
@@ -62,10 +62,10 @@ def test_dataset_navigator():
 def test_dataset_map_view():
     settings = {
         "pattern": "",
-        "color_mapper": bokeh.models.ColorMapper()
     }
+    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("eida50", settings)
-    view = dataset.map_view()
+    view = dataset.map_view(color_mapper)
     view.render({})
 
 

--- a/test/test_drivers_gpm.py
+++ b/test/test_drivers_gpm.py
@@ -6,12 +6,10 @@ import forest.drivers.gpm
 
 
 def test_gpm_dataset():
-    settings = {
-        "color_mapper": bokeh.models.ColorMapper()
-    }
-    dataset = forest.drivers.get_dataset("gpm", settings)
+    color_mapper = bokeh.models.ColorMapper()
+    dataset = forest.drivers.get_dataset("gpm")
     navigator = dataset.navigator()
-    map_view = dataset.map_view()
+    map_view = dataset.map_view(color_mapper)
     map_view.render({})
     assert hasattr(map_view, "image_sources")
 

--- a/test/test_drivers_intake_loader.py
+++ b/test/test_drivers_intake_loader.py
@@ -13,9 +13,9 @@ def test_dataset_map_view():
     pattern = "a_b_c_d_e_f"
     dataset = forest.drivers.get_dataset("intake_loader", {
         "pattern": pattern,
-        "color_mapper": bokeh.models.ColorMapper()
     })
-    map_view = dataset.map_view()
+    color_mapper = bokeh.models.ColorMapper()
+    map_view = dataset.map_view(color_mapper)
     assert isinstance(map_view, forest.view.UMView)
     assert map_view.tooltips == forest.drivers.intake_loader.INTAKE_TOOLTIPS
     assert map_view.formatters == forest.drivers.intake_loader.INTAKE_FORMATTERS

--- a/test/test_drivers_nearcast.py
+++ b/test/test_drivers_nearcast.py
@@ -14,9 +14,9 @@ def test_dataset_navigator():
 
 
 def test_dataset_map_view():
-    settings = {"color_mapper": bokeh.models.ColorMapper()}
-    dataset = forest.drivers.get_dataset("nearcast", settings)
-    map_view = dataset.map_view()
+    color_mapper = bokeh.models.ColorMapper()
+    dataset = forest.drivers.get_dataset("nearcast")
+    map_view = dataset.map_view(color_mapper)
     assert isinstance(map_view, forest.view.NearCast)
     assert map_view.tooltips == forest.drivers.nearcast.NEARCAST_TOOLTIPS
 

--- a/test/test_drivers_saf.py
+++ b/test/test_drivers_saf.py
@@ -7,10 +7,8 @@ from forest.drivers import saf
 
 @pytest.fixture
 def dataset():
-    color_mapper = bokeh.models.ColorMapper()
     return forest.drivers.get_dataset("saf", {
         "pattern": "saf.nc",
-        "color_mapper": color_mapper
     })
 
 
@@ -20,7 +18,8 @@ def navigator():
 
 
 def test_dataset_map_view(dataset):
-    assert isinstance(dataset.map_view(), forest.view.UMView)
+    color_mapper = bokeh.models.ColorMapper()
+    assert isinstance(dataset.map_view(color_mapper), forest.view.UMView)
 
 
 def test_dataset_navigator(dataset):

--- a/test/test_drivers_unified_model.py
+++ b/test/test_drivers_unified_model.py
@@ -12,10 +12,10 @@ import iris
 def test_dataset_loader_pattern():
     settings = {
         "pattern": "*.nc",
-        "color_mapper": bokeh.models.ColorMapper()
     }
+    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view()
+    view = dataset.map_view(color_mapper)
     assert isinstance(view.loader, forest.drivers.unified_model.Loader)
 
 
@@ -43,10 +43,10 @@ def test_loader_use_database(tmpdir):
         "directory": "/replace",
         "locator": "database",
         "database_path": database_path,
-        "color_mapper": bokeh.models.ColorMapper()
     }
+    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view()
+    view = dataset.map_view(color_mapper)
     assert hasattr(view.loader.locator, "connection")
     assert view.loader.locator.directory == "/replace"
 
@@ -62,10 +62,10 @@ def test_view_render_state(tmpdir):
         var.coords = "time"  # Needed by Locator
     settings = {
         "pattern": path,
-        "color_mapper": bokeh.models.ColorMapper()
     }
+    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view()
+    view = dataset.map_view(color_mapper)
     view.render({
         "initial_time": dt.datetime(2020, 1, 1),
         "valid_time": dt.datetime(2020, 1, 1),

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -6,10 +6,10 @@ from forest.drivers import rdt
 
 
 def test_build_loader_given_files():
-    settings = {"pattern": "file_20190101T0000Z.nc",
-                "color_mapper": bokeh.models.ColorMapper()}
+    settings = {"pattern": "file_20190101T0000Z.nc"}
+    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view()
+    view = dataset.map_view(color_mapper)
     assert isinstance(view.loader, forest.drivers.unified_model.Loader)
     assert isinstance(view.loader.locator, forest.drivers.unified_model.Locator)
 


### PR DESCRIPTION
# Optimize EIDA50

To accelerate meta-data checking a database layer and more granular middleware is needed. To allow the Navigator to redefine the time axis as the user travels through the dataset

- [x] Add a Database layer to cache meta-data between sessions
- [x] Add support for `navigator.valid_times()` query on `set_valid_time()`, probably only relevant for EIDA50 at the moment. Actually, generalised to make Navigators middleware in their own right
- [x] Implement server wide caching and update from database
- [x] Refactor to move `color_mapper` into `map_view(color_mapper)` since they are different for every session (e.g. browser tab)
## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
