### PR TITLE
Rdt netcdf revisited

### DIFF
--- a/forest/rdt.py
+++ b/forest/rdt.py
@@ -8,7 +8,11 @@ import re
 import datetime as dt
 import bokeh
 import json
+import netCDF4 as nc
 import numpy as np
+import numpy.ma as ma
+import cf_units
+from geojson import GeometryCollection, Point, LineString, Polygon, Feature, FeatureCollection, dump
 from forest import (
         geo,
         locate)
@@ -19,6 +23,7 @@ from bokeh.palettes import GnBu3, OrRd3
 import itertools
 import math
 from forest.drivers.gridded_forecast import _to_datetime
+import pdb
 
 
 class RenderGroup(object):
@@ -119,6 +124,7 @@ class View(object):
                 NumIdBirth=[],
                 MvtSpeed=[],
                 MvtDirection=[])
+
         self.color_mapper = bokeh.models.CategoricalColorMapper(
                 palette=['#fee8c8', '#fdbb84', '#e34a33', '#43a2ca', '#a8ddb5'],
                 factors=["Triggering", "Triggering from split", "Growing", "Mature", "Decaying"])
@@ -133,6 +139,7 @@ class View(object):
         """Gets called when a menu button is clicked (or when application state changes)"""
         if state.valid_time is not None:
             date = _to_datetime(state.valid_time)
+            # print(self.tail_line_source.data)
             try:
                 (self.source.geojson,
                  self.tail_line_source.data,
@@ -194,18 +201,33 @@ class Loader(object):
 
     def load_date(self, date):
         file_name = self.locator.find_file(date)
-        return (
-                self.load_polygon(file_name),
-                self.load_tail_lines(file_name),
-                self.load_tail_points(file_name),
-                self.load_centre_points(file_name))
+        print(file_name)
+        if os.path.splitext(file_name)[1] == '.nc':
+            # print(self.load_tail_lines_netcdf(file_name))
+            return(
+                self.load_polygon_netcdf(file_name),
+                self.load_tail_lines_netcdf(file_name),
+                self.load_tail_points_netcdf(file_name),
+                self.load_centre_points_netcdf(file_name)
+            )
+        elif os.path.splitext(file_name)[1] == '.json':
+            # print(self.load_polygon_json(file_name))
+            return (
+                self.load_polygon_json(file_name),
+                self.load_tail_lines_json(file_name),
+                self.load_tail_points_json(file_name),
+                self.load_centre_points_json(file_name)
+            )
+        else:
+            return 'File extension not recognised: ' + file_name
 
     @staticmethod
-    def load_polygon(path):
+    def load_polygon_json(path):
         """Load GeoJSON string representation of Polygons from file
 
         :returns: GeoJSON str
         """
+
         with open(path) as stream:
             rdt = json.load(stream)
 
@@ -243,7 +265,18 @@ class Loader(object):
         return json.dumps(copy)
 
     @staticmethod
-    def load_tail_lines(path):
+    def load_polygon_netcdf(path):
+        """
+        Loads polygons from netcdf
+        :param path: absolute path and filename
+        :return: geojson object for plotting in bokeh
+        """
+
+        return getRDT(path, 0, 'Polygon')
+
+
+    @staticmethod
+    def load_tail_lines_json(path):
         """Load tail line data from file
 
         :returns: dict representation suitable for ColumnDataSource
@@ -252,21 +285,7 @@ class Loader(object):
             rdt = json.load(stream)
 
         # Create an empty dictionary
-        mydict = dict(
-                xs=[], ys=[],
-                LonTrajCellCG=[],
-                LatTrajCellCG=[],
-                NumIdCell=[],
-                NumIdBirth=[],
-                DTimeTraj=[],
-                BTempTraj=[],
-                BTminTraj=[],
-                BaseAreaTraj=[],
-                TopAreaTraj=[],
-                CoolingRateTraj=[],
-                ExpanRateTraj=[],
-                SpeedTraj=[],
-                DirTraj=[])
+        mydict = get_empty_feature_dict('Tail_Lines')
 
         # Loop through features
         for i, feature in enumerate(rdt["features"]):
@@ -288,29 +307,27 @@ class Loader(object):
             xs, ys = geo.web_mercator(lons, lats)
             mydict['xs'].append(xs)
             mydict['ys'].append(ys)
+
         return mydict
 
     @staticmethod
-    def load_tail_points(path):
+    def load_tail_lines_netcdf(path):
+        """
+        Loads tail lines from the netcdf file
+        :param path: absolute path and filename
+        :return: dictionary of data for plotting as a ColumnDataSource in bokeh
+        """
+
+        return getRDT(path, 0, 'Tail_Lines')
+
+
+    @staticmethod
+    def load_tail_points_json(path):
         with open(path) as stream:
             rdt = json.load(stream)
 
         # Create an empty dictionary
-        mydict = dict(
-                x=[], y=[],
-                LonTrajCellCG=[],
-                LatTrajCellCG=[],
-                NumIdCell=[],
-                NumIdBirth=[],
-                DTimeTraj=[],
-                BTempTraj=[],
-                BTminTraj=[],
-                BaseAreaTraj=[],
-                TopAreaTraj=[],
-                CoolingRateTraj=[],
-                ExpanRateTraj=[],
-                SpeedTraj=[],
-                DirTraj=[])
+        mydict = get_empty_feature_dict('Tail_Points')
 
         # Loop through features
         for i, feature in enumerate(rdt["features"]):
@@ -340,27 +357,24 @@ class Loader(object):
         return mydict
 
     @staticmethod
-    def load_centre_points(path):
+    def load_tail_points_netcdf(path):
+        """
+        Loads tail points from the netcdf file
+        :param path: absolute path and filename
+        :return: dictionary of data for plotting as a ColumnDataSource in bokeh
+        """
+
+        return getRDT(path, 0, 'Tail_Points')
+
+    @staticmethod
+    def load_centre_points_json(path):
         """Holds a centre point, future point and future movement line"""
-        if os.path.splitext(path)[1] == '.json':
-            with open(path) as stream:
-                rdt = json.load(stream)
-        elif os.path.splitext(path)[1] == '.nc':
-            getRDT(path, 0, 'Point')
-        else:
-            return 'Can\'t read this file type'
+
+        with open(path) as stream:
+            rdt = json.load(stream)
 
         # Create an empty dictionary
-        mydict = dict(
-                x1=[], y1=[], x2=[], y2=[], xs=[], ys=[],
-                Arrowxs=[],
-                Arrowys=[],
-                LonG=[],
-                LatG=[],
-                NumIdCell=[],
-                NumIdBirth=[],
-                MvtSpeed=[],
-                MvtDirection=[])
+        mydict = get_empty_feature_dict('Centre_Point')
 
         # Loop through features
         for i, feature in enumerate(rdt["features"]):
@@ -388,20 +402,90 @@ class Loader(object):
                 direction = float(feature['properties']['MvtDirection'])
             except ValueError:
                 direction = 0
-            lon2, lat2 = calc_dst_point(lon, lat, speed, direction)
-            x2, y2 = geo.web_mercator(lon2, lat2)
-            mydict['x2'].extend(x2)
-            mydict['y2'].extend(y2)
-            mydict['xs'].append([x1, x2])
-            mydict['ys'].append([y1, y2])
 
-            # Now calculate arrow polygon
-            x3d, y3d, x4d, y4d = get_arrow_poly(lon2, lat2, speed, direction)
-            [x3, x4], [y3, y4] = geo.web_mercator([x3d, x4d], [y3d, y4d])
+            mydict = make_arrow(mydict, lon, lat, speed, direction)
 
-            mydict['Arrowxs'].append([x2[0], x3, x4])
-            mydict['Arrowys'].append([y2[0], y3, y4])
         return mydict
+
+    @staticmethod
+    def load_centre_points_netcdf(path):
+        """
+        Loads tail points from the netcdf file
+        :param path: absolute path and filename
+        :return: dictionary of data for plotting as a ColumnDataSource in bokeh
+        """
+
+        return getRDT(path, 0, 'Centre_Point')
+
+
+def make_arrow(mydict, lon, lat, speed, direction):
+
+    lon2, lat2 = calc_dst_point(lon, lat, speed, direction)
+    x1, y1 = geo.web_mercator(lon, lat)
+    x2, y2 = geo.web_mercator(lon2, lat2)
+    mydict['x2'].extend(x2)
+    mydict['y2'].extend(y2)
+    mydict['xs'].append([x1, x2])
+    mydict['ys'].append([y1, y2])
+
+    # Now calculate arrow polygon
+    x3d, y3d, x4d, y4d = get_arrow_poly(lon2, lat2, speed, direction)
+    [x3, x4], [y3, y4] = geo.web_mercator([x3d, x4d], [y3d, y4d])
+
+    mydict['Arrowxs'].append([x2[0], x3, x4])
+    mydict['Arrowys'].append([y2[0], y3, y4])
+
+    return mydict
+
+def get_empty_feature_dict(type):
+
+    if type == 'Tail_Lines':
+        return dict(
+                xs=[], ys=[],
+                LonTrajCellCG=[],
+                LatTrajCellCG=[],
+                NumIdCell=[],
+                NumIdBirth=[],
+                DTimeTraj=[],
+                BTempTraj=[],
+                BTminTraj=[],
+                BaseAreaTraj=[],
+                TopAreaTraj=[],
+                CoolingRateTraj=[],
+                ExpanRateTraj=[],
+                SpeedTraj=[],
+                DirTraj=[])
+
+    if type == 'Tail_Points':
+        return dict(
+                x=[], y=[],
+                LonTrajCellCG=[],
+                LatTrajCellCG=[],
+                NumIdCell=[],
+                NumIdBirth=[],
+                DTimeTraj=[],
+                BTempTraj=[],
+                BTminTraj=[],
+                BaseAreaTraj=[],
+                TopAreaTraj=[],
+                CoolingRateTraj=[],
+                ExpanRateTraj=[],
+                SpeedTraj=[],
+                DirTraj=[])
+
+    if type == 'Centre_Point':
+        return dict(
+                x1=[], y1=[], x2=[], y2=[], xs=[], ys=[],
+                Arrowxs=[],
+                Arrowys=[],
+                LonG=[],
+                LatG=[],
+                NumIdCell=[],
+                NumIdBirth=[],
+                MvtSpeed=[],
+                MvtDirection=[])
+    else:
+        return type + ': Not a valid feature type'
 
 
 def getRDT(path, lev, type):
@@ -410,7 +494,7 @@ def getRDT(path, lev, type):
     Gets RDT data from the netcdf output of the NWCSAF software
     :param path: Full path and filename of the netcdf file
     :param lev: [0,1] Level number. 0 = bottom of the cloud, 1 = top of the cloud (heights vary between clouds)
-    :param type: ['Point', 'Polygon', 'Traj_Point', 'Traj_Line]
+    :param type: ['All', 'Centre_Point', 'Polygon', 'Tail_Points', 'Tail_Lines', 'Gridded']
     :return: geojson feature collection object for plotting
     '''
 
@@ -435,78 +519,233 @@ def getRDT(path, lev, type):
     # How many cloud levels have we got? It should only be 2 (cloud top and bottom)
     dimsize = len(ma.getdata(ncds.variables[varlev[0]][0,:]))
 
+    # Convert units from the netcdf
+    unitsToRescale = {'Pa': 'hPa'} #, 'K': 'degC'}
+    # Get text labels instead of numbers for certain fields
+    fieldsToLookup = ['PhaseLife', 'SeverityType', 'SeverityIntensity', 'ConvType', 'CType']
+
     # Check the lev is within the dimsize
     if not lev in np.arange(dimsize):
         return 'Please enter a valid level number (0 or 1)'
+    else:
+        list_to_return = []
 
-    # Create list of features to populate
-    features = []
+    # Do specific things for each feature type
+    if type in ['Centre_Point', 'All']:
 
-    for i in np.arange(ncds.dimensions['recNUM'].size):
+        # Create an empty dictionary
+        mydict_cp = get_empty_feature_dict('Centre_Point')
 
-        if type == 'Point':
+        for i in np.arange(ncds.dimensions['recNUM'].size):
 
             # Get the Point features
-            lat_pt = ncds.variables['LatG'][i, lev]
-            lon_pt = ncds.variables['LonG'][i, lev]
-            this_pt = Point((float(lon_pt), float(lat_pt)))
+            lat = ncds.variables['LatG'][i, lev]
+            lon = ncds.variables['LonG'][i, lev]
+            x1, y1 = geo.web_mercator(lon, lat)
+            mydict_cp['x1'].extend(x1)
+            mydict_cp['y1'].extend(y1)
 
-            # Get the properties for this point
-            pt_props = {}
-            for var in allvars:
-                if var in varlev:
-                    thisdata = ncds.variables[var][i, lev]
-                else:
-                    thisdata = ncds.variables[var][i]
-                datatype = ncds.variables[var].datatype
-                update_json(pt_props, var, thisdata, datatype)
+            mykeys = [k for k in mydict_cp.keys() if not (('x' in k) or ('y' in k))]
+            for k in mykeys:
+                try:
+                    if k in varlev:
+                        thisdata = ncds.variables[k][i, lev]
+                    else:
+                        thisdata = ncds.variables[k][i]
 
-            features.append(Feature(geometry=this_pt, properties=pt_props))
+                    thisdata, units = descale_rdt(k, thisdata) # May not need to do this
+                    mydict_cp[k].append(thisdata)
+                except:
+                    mydict_cp[k].append(None)
 
-        if type == 'Polygons':
+            # Now calculate future point and line
+            try:
+                speed = float(ncds.variables['MvtSpeed'][i])
+            except ValueError:
+                speed = 0
+            try:
+                direction = float(ncds.variables['MvtDirection'][i])
+            except ValueError:
+                direction = 0
+
+            mydict_cp = make_arrow(mydict_cp, lon, lat, speed, direction)
+
+        list_to_return.append(mydict_cp)
+
+    if type in ['Polygon', 'All']:
+
+        # Create list of features to populate
+        features = []
+        fieldsToLookup = ['PhaseLife', 'SeverityType', 'SeverityIntensity', 'ConvType', 'CType']
+        for i in np.arange(ncds.dimensions['recNUM'].size):
+
             # do something
-            ypolcoords = getDataOnly(ncds.variables['LatContour'][i, lev, :])
-            xpolcoords = getDataOnly(ncds.variables['LonContour'][i, lev, :])
+            ypolcoords_ll = getDataOnly(ncds.variables['LatContour'][i, lev, :])
+            xpolcoords_ll = getDataOnly(ncds.variables['LonContour'][i, lev, :])
+
+            xpolcoords, ypolcoords = geo.web_mercator(xpolcoords_ll, ypolcoords_ll)
 
             this_poly = Polygon([[(float(coord[0]), float(coord[1])) for coord in zip(xpolcoords, ypolcoords)]])
 
             # Get the properties for this polygon
             pol_props = {}
             for var in allvars:
+
                 if var in varlev:
                     thisdata = ncds.variables[var][i, lev]
                 else:
                     thisdata = ncds.variables[var][i]
+
+                thisdata_scaled = convert_values(thisdata, ncds.variables[var])
                 datatype = ncds.variables[var].datatype
-                update_json(pol_props, var, thisdata, datatype)
+
+                if var in fieldsToLookup:
+                    try:
+                        thisdata_scaled = fieldValueLUT(var, int(thisdata))
+                        datatype = 'string'
+                    except:
+                        continue
+
+                update_json(pol_props, var, thisdata_scaled, datatype)
 
             features.append(Feature(geometry=this_poly, properties=pol_props))
 
-        if type == 'Traj_Point':
+        feature_collection = FeatureCollection(features)
+        
+        list_to_return.append(json.dumps(feature_collection))
+        
+
+    if type in ['Tail_Points', 'All']:
+
+        # Create an empty dictionary
+        mydict_tp = get_empty_feature_dict('Tail_Points')
+
+        for i in np.arange(ncds.dimensions['recNUM'].size):
+
             # do something
+            npts = len(getDataOnly(ncds.variables['LonTrajCellCG'][i]))
+            mykeys = [k for k in mydict_tp.keys() if k not in ['x', 'y']]
+            for k in mykeys:
 
-            lat_pts = getDataOnly(ncds.variables['LatTrajCellCG'][i, :])
-            lon_pts = getDataOnly(ncds.variables['LonTrajCellCG'][i, :])
+                thisdata = getDataOnly(ncds.variables[k][i]).tolist()
 
-            for j, coords in enumerate(zip(lon_pts, lat_pts)):
-                this_trajpt = Point((float(coords[0]), float(coords[1])))
-                trajpt_props = {}
-                for var in vartraj:
-                    thisdata = ncds.variables[var][i, j]
-                    datatype = ncds.variables[var].datatype
-                    update_json(trajpt_props, var, thisdata, datatype)
+                try:
+                    if len(thisdata) == 1:
+                        thisdata = thisdata[0]
+                except:
+                    pass
 
-                features.append(Feature(geometry=this_trajpt, properties=trajpt_props))
+                if isinstance(thisdata, list) and (npts == len(thisdata)):
+                    datalist, units = descale_rdt(k, thisdata)
+                    mydict_tp[k].extend(datalist)
+                else:
+                    # Repeat the data value npts times
+                    datalist = [i for i in itertools.repeat(thisdata, npts)]
+                    thisdata, units = descale_rdt(k, datalist)
+                    mydict_tp[k].extend(datalist)
 
-        if type == 'Traj_Line':
-            # do something
-            lat_linepts = getDataOnly(ncds.variables['LatTrajCellCG'][i, :])
-            lon_linepts = getDataOnly(ncds.variables['LonTrajCellCG'][i, :])
+                # Some records don't have any data. Mostly happens for ExpanRateTraj
+                if len(thisdata) == 0:
+                    datalist = [i for i in itertools.repeat('-', npts)]
+                    mydict_tp[k].extend(datalist)
+
+                # Some records seem to have missing values
+                if len(datalist) != npts:
+                    pdb.set_trace()
+
+            lats = getDataOnly(ncds.variables['LatTrajCellCG'][i, :])
+            lons = getDataOnly(ncds.variables['LonTrajCellCG'][i, :])
+            x, y = geo.web_mercator(lons, lats)
+            mydict_tp['x'].extend(x)
+            mydict_tp['y'].extend(y)
+
+        list_to_return.append(mydict_tp)
 
 
+    if type in ['Tail_Lines', 'All']:
 
-    feature_collection = FeatureCollection(features)
-    return feature_collection
+        # Create an empty dictionary
+        mydict_tl = get_empty_feature_dict('Tail_Lines')
+
+        # Loop through features
+        for i in np.arange(ncds.dimensions['recNUM'].size):
+
+            # Loop through all items in mydict_tl
+            for k in mydict_tl.keys():
+                try:
+                    thisdata, units = descale_rdt(k, getDataOnly(ncds.variables[k][:]))
+                    mydict_tl[k].append(thisdata)
+                except:
+                    # Do nothing at the moment with the xs and ys
+                    if not k in ['xs', 'ys']:
+                        mydict_tl[k].append(None)
+                    else:
+                        continue
+
+            lats = getDataOnly(ncds.variables['LatTrajCellCG'][i, :])
+            lons = getDataOnly(ncds.variables['LonTrajCellCG'][i, :])
+
+            xs, ys = geo.web_mercator(lons, lats)
+            mydict_tl['xs'].append(xs)
+            mydict_tl['ys'].append(ys)
+
+        list_to_return.append(mydict_tl)
+
+    if len(list_to_return) == 1:
+        return list_to_return[0]
+    elif len(list_to_return) > 1:
+        return list_to_return
+    else:
+        return 'Nothing to return'
+
+
+def getDataOnly(array1d):
+    '''
+    Removes redundant no data slots in a 1D array
+    Note that sometimes data is missing within the array, so in the majority of cases, the array just needs to be shortened, but in a small number of cases, the 'within array' no data needs to be replaced
+    :param array1d:
+    :return: Simple array of numbers
+    '''
+
+    if np.any(ma.getmask(array1d)):
+        # fv = ncds.variables[k][i].fill_value
+        mymask = np.invert(ma.getmask(array1d))
+        outarray = ma.getdata(array1d)[mymask]
+    else:
+        outarray = ma.getdata(array1d)
+
+    return outarray
+
+def update_json(props, varname, data, datatype):
+    """
+    Adds an extra field to the properties of a feature in a geojson file. Provides a consistent way to handle different data types
+    :param props: dictionary of properties
+    :param varname: string variable name
+    :param data: the data to add
+    :param datatype: datatype
+    :return: updated props
+    """
+
+    if isinstance(data, ma.MaskedArray) and (data.shape == ()) and ('int' in str(datatype)):
+        props.update({varname: np.int(ma.getdata(data))})
+
+    elif isinstance(data, ma.MaskedArray) and (data.shape == ()) and ('float' in str(datatype)):
+        props.update({varname: np.float(ma.getdata(data))})
+
+    elif isinstance(data, np.float32) or isinstance(data, np.float):
+        props.update({varname: float(data)})
+
+    elif isinstance(data, np.int) or isinstance(data, np.uint16):
+        props.update({varname: int(data)})
+
+    elif str(datatype) == 'string':
+        props.update({varname: str(data)})
+
+    else:
+        # pdb.set_trace()
+        # print(varname + ': Couldn\'t save data | ' + str(datatype))
+        return
+
 
 
 def calc_dst_point(x1d, y1d, speed, angle):
@@ -577,6 +816,62 @@ def get_arrow_poly(x2,y2, speed, direction):
     # Calculate x3, y3
     x4, y4 = calc_dst_point(x2, y2, pt2_speed, pt2_dir)
     return x3, y3, x4, y4
+
+
+def convert_values(conv_value, conv_var):
+    """ Specific conversions for GeoJSON storage efficiency """
+
+    DP_ACCURACY = 0
+    # print(conv_value)
+    # print(type(conv_value))
+
+    if conv_var.name == 'ExpansionRate':
+        try:
+            return int(round(conv_value * 360000, DP_ACCURACY))  # to %/hr
+        except TypeError:
+            return conv_value
+
+    elif conv_var.name == 'CoolingRate':
+        try:
+            return int(round(conv_value * 3600, DP_ACCURACY))  # to K/hr
+        except TypeError:
+            return conv_value
+
+    elif conv_var.name == 'Surface':
+        try:
+            return int(round(conv_value / 1e6, DP_ACCURACY))  # to km2
+        except TypeError:
+            return conv_value
+
+    elif conv_var.name == 'CTPressure':
+        myu = cf_units.Unit('Pa')
+        try:
+            return int(round(myu.convert(conv_value, 'hPa'), DP_ACCURACY))
+        except TypeError:
+            return conv_value
+
+    elif conv_var.name == 'CRainRate':
+        try:
+            return int(round(conv_value, DP_ACCURACY)) # Round and make it an integer
+        except TypeError:
+            return conv_value
+
+    elif conv_var.name == 'CTPressRate':
+        myu = cf_units.Unit('Pa s-1')
+        try:
+            return int(round(myu.convert(conv_value, 'hPa h-1'), DP_ACCURACY)) # Pa/s to hPa/hour
+        except TypeError:
+            return conv_value
+
+    elif conv_var.name in ['BTemp', 'BTmin', 'BTmoy']:
+        myu = cf_units.Unit('K')
+        try:
+            return round(myu.convert(conv_value, 'degC'), 1)
+        except TypeError:
+            return conv_value
+
+    else:
+        return conv_value
 
 
 def descale_rdt(fn, data):
@@ -826,7 +1121,7 @@ class Locator(object):
         self.pattern = pattern
 
     def find_file(self, valid_date):
-        paths = np.array(self.paths)  # Note: timeout cache in use
+        paths = np.array(self.paths)  # Note: timeout cache in use)
         bounds = locate.bounds(
                 self.dates(paths),
                 dt.timedelta(minutes=15))
@@ -853,9 +1148,16 @@ class Locator(object):
 
     @staticmethod
     def parse_date(path):
-        groups = re.search(r"[0-9]{12}", os.path.basename(path))
-        if groups is not None:
-            return dt.datetime.strptime(groups[0], "%Y%m%d%H%M")
+        if os.path.splitext(path)[1] == '.json':
+            groups = re.search(r"[0-9]{12}", os.path.basename(path))
+            if groups is not None:
+                return dt.datetime.strptime(groups[0], "%Y%m%d%H%M")
+        elif os.path.splitext(path)[1] == '.nc':
+            groups = re.search(r"[0-9]{8}T[0-9]{6}", os.path.basename(path))
+            if groups is not None:
+                return dt.datetime.strptime(groups[0], "%Y%m%dT%H%M%S")
+        else:
+            return 'Unable to parse datetime from filename'
 
 
 class Coordinates(object):


### PR DESCRIPTION
# Getting FOREST to read NWC/SAF RDT netcdf files

The existing code used geojson files created internally in the Met Office. This code works on the NWC/SAF netcdf files, so it can be used on external implementations 

## Check list

You could remove the loader functions (e.g. self.load_polygon_netcdf(file_name)) as they're redundant code now that I adapted the netcdf loader to grab all the map elements at once
