### PR TITLE
WIP Multiple ColorMappers

### DIFF
--- a/forest/components/__init__.py
+++ b/forest/components/__init__.py
@@ -1,5 +1,5 @@
 from .time import TimeUI
-from .colorbar import ColorbarUI
+from .colorbar import Colorbars
 from .headline import Headline
 from .modal import Modal
 from .tiles import TilePicker

--- a/forest/components/colorbar.py
+++ b/forest/components/colorbar.py
@@ -1,10 +1,12 @@
 """Colorbar sub-figure component"""
 import bokeh.plotting
+import bokeh.models
+from forest.colors import one_way_connect, ColorSpec
 
 
-class ColorbarUI:
-    """Helper to make a figure containing only one colorbar"""
-    def __init__(self, color_mapper):
+class Colorbars:
+    """Helper to layout/maintain colorbars"""
+    def __init__(self):
         # Dimensions
         padding = 5
         margin = 20
@@ -12,9 +14,15 @@ class ColorbarUI:
         plot_height = colorbar_height + 30
         plot_width = 500
 
+        # LinearColorMapper
+        self.color_mapper = bokeh.models.LinearColorMapper(
+                low=0,
+                high=1,
+                palette=bokeh.palettes.Plasma[256])
+
         # Colorbar
         self.colorbar = bokeh.models.ColorBar(
-            color_mapper=color_mapper,
+            color_mapper=self.color_mapper,
             location=(0, 0),
             height=colorbar_height,
             width=int(plot_width - (margin + padding)),
@@ -40,3 +48,20 @@ class ColorbarUI:
         self.figure.add_layout(self.colorbar, 'center')
 
         self.layout = self.figure
+
+    def connect(self, store):
+        one_way_connect(self, store)
+        return self
+
+    def render(self, props):
+        # Make ColorSpec from props
+        # TODO: Tidy-up awkward mapping from props to ColorSpec
+        kwargs = {k: v for k, v in props.items()
+                  if k in ["name", "number", "low", "high", "reverse"]}
+        if "invisible_min" in props:
+            kwargs["low_visible"] = not props["invisible_min"]
+        if "invisible_max" in props:
+            kwargs["high_visible"] = not props["invisible_max"]
+        spec = ColorSpec(**kwargs)
+        print(f"forest.components.Colorbars {spec}")
+        spec.apply(self.color_mapper)

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -8,12 +8,13 @@ import xarray
 import numpy as np
 from functools import lru_cache
 from forest.exceptions import FileNotFound, IndexNotFound
-from forest.old_state import old_state, unique
 import forest.util
+import forest.colors
+import forest.view
 from forest import (
         geo,
-        locate,
-        view)
+        locate)
+
 
 
 ENGINE = "h5netcdf"
@@ -27,8 +28,8 @@ def _natargmax(arr):
 
 
 class Dataset:
-    def __init__(self, pattern=None, database_path=None, **kwargs):
-        print("NEW EIDA50 DATASET")
+    def __init__(self, label=None, pattern=None, database_path=None, **kwargs):
+        self.label = label
         self.pattern = pattern
         if database_path is None:
             database_path = ":memory:"
@@ -38,9 +39,11 @@ class Dataset:
     def navigator(self):
         return Navigator(self.locator, self.database)
 
-    def map_view(self, color_mapper):
+    def map_view(self):
+        """Create a representation to add to a map"""
         loader = Loader(self.locator)
-        return view.UMView(loader, color_mapper, use_hover_tool=False)
+        return forest.view.color_image(self.label, loader,
+                                       use_hover_tool=False)
 
 
 class Database:

--- a/forest/drivers/unified_model.py
+++ b/forest/drivers/unified_model.py
@@ -8,11 +8,11 @@ import datetime as dt
 import numpy as np
 import netCDF4
 import forest.util
+import forest.view
 from forest import (
     db,
     disk,
-    geo,
-    view)
+    geo)
 from forest.exceptions import SearchFail, PressuresNotFound
 from forest.drivers import gridded_forecast
 try:
@@ -50,10 +50,9 @@ class Dataset:
         else:
             return Navigator(self.pattern)
 
-    def map_view(self, color_mapper):
-        return view.UMView(Loader(self.label,
-                                  self.pattern,
-                                  self.locator), color_mapper)
+    def map_view(self):
+        loader = Loader(self.label, self.pattern, self.locator)
+        return forest.view.color_image(self.label, loader)
 
 
 class Navigator:

--- a/forest/layers.py
+++ b/forest/layers.py
@@ -605,13 +605,11 @@ class Factory:
     in future releases
     """
     def __init__(self, dataset,
-                 color_mapper,
                  figures,
                  source_limits,
                  opacity_slider):
         self._calls = 0
         self.dataset = dataset
-        self.color_mapper = color_mapper
         self.figures = figures
         self.source_limits = source_limits
         self.opacity_slider = opacity_slider
@@ -620,10 +618,7 @@ class Factory:
         """Complex construction"""
         self._calls += 1
         print("Factory.__call__: {}".format(self._calls))
-        try:
-            map_view = self.dataset.map_view(self.color_mapper)
-        except TypeError:
-            map_view = self.dataset.map_view()
+        map_view = self.dataset.map_view()
         visible = Visible.from_map_view(map_view, self.figures)
         if self.opacity_slider is not None:
             self.opacity_slider.add_renderers(visible.renderers)

--- a/forest/main.py
+++ b/forest/main.py
@@ -74,13 +74,9 @@ def main(argv=None):
 
     figure_row = layers.FigureRow(figures)
 
-    color_mapper = bokeh.models.LinearColorMapper(
-            low=0,
-            high=1,
-            palette=bokeh.palettes.Plasma[256])
-
-    # Colorbar user interface
-    colorbar_ui = forest.components.ColorbarUI(color_mapper)
+    # TODO: Move this to colorbars.connect() statement when all layers
+    #       make their own ColorMappers
+    colorbars = forest.components.Colorbars()
 
     # Convert config to datasets
     datasets = {}
@@ -189,8 +185,7 @@ def main(argv=None):
     # Connect MapView orchestration to store
     opacity_slider = forest.layers.OpacitySlider()
     source_limits = colors.SourceLimits().connect(store)
-    factory_class = forest.layers.factory(color_mapper,
-                                          figures,
+    factory_class = forest.layers.factory(figures,
                                           source_limits,
                                           opacity_slider)
     gallery = forest.layers.Gallery.from_datasets(datasets, factory_class)
@@ -232,8 +227,11 @@ def main(argv=None):
             tile_picker.add_figure(figure)
         tile_picker.connect(store)
 
-    # Connect color palette controls
-    color_palette = colors.ColorPalette(color_mapper).connect(store)
+    # Connect colorbar legends to the store
+    colorbars.connect(store)
+
+    # Connect colorbar controls
+    colorbar_controls = colors.ColorbarControls().connect(store)
 
     # Connect limit controllers to store
     user_limits = colors.UserLimits().connect(store)
@@ -295,7 +293,7 @@ def main(argv=None):
         border_row,
         opacity_slider.layout,
         preset_ui.layout,
-        color_palette.layout,
+        colorbar_controls.layout,
         user_limits.layout,
         bokeh.models.Div(text="Tiles:"),
     ]
@@ -391,7 +389,7 @@ def main(argv=None):
     for root in navbar.roots:
         document.add_root(root)
     document.add_root(
-        bokeh.layouts.row(colorbar_ui.layout, name="colorbar"))
+        bokeh.layouts.row(colorbars.layout, name="colorbar"))
     document.add_root(figure_row.layout)
     document.add_root(key_press.hidden_button)
     document.add_root(modal.layout)

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -1,6 +1,7 @@
 import unittest.mock
 from unittest.mock import Mock, sentinel
 import pytest
+import forest
 import forest.components
 from forest import colors, main, redux, db
 import bokeh.models
@@ -16,15 +17,40 @@ def listener():
     ({}, colors.set_palette_name("Accent"), {"colorbar": {"name": "Accent"}}),
     ({}, colors.set_palette_number(3), {"colorbar": {"number": 3}}),
     ({}, colors.set_palette_numbers([1, 2 ,3]), {"colorbar": {"numbers": [1, 2, 3]}}),
-    ({}, colors.set_user_high(100), {}),
-    ({}, colors.set_user_low(0), {}),
-    ({}, colors.set_source_limits(0, 100), {}),
+    pytest.param({}, colors.set_user_high(100), {
+        "colorbar": {
+            "limits": {
+                "user": {
+                    "high": 100
+                }
+            }
+        }
+    }, id="set user high"),
+    pytest.param({}, colors.set_user_low(0), {
+        "colorbar": {
+            "limits": {
+                "user": {
+                    "low": 0
+                }
+            }
+        }
+    }, id="set user low"),
+    pytest.param({}, colors.set_source_limits(0, 100), {
+        "colorbar": {
+            "limits": {
+                "column_data_source": {
+                    "low": 0,
+                    "high": 100
+                }
+            }
+        }
+    }, id="set source limits"),
     ({}, colors.set_colorbar({"key": "value"}), {"colorbar": {"key": "value"}}),
     ({}, colors.set_palette_names(["example"]), {"colorbar": {"names": ["example"]}}),
     ({}, colors.set_edit_layer("Foo"), {"colorbar": {"edit": "Foo"}}),
 ])
 def test_reducer_sets_colorbar_namespace(state, action, expect):
-    result = colors.reducer(state, action)
+    result = forest.reducer(state, action)
     assert expect == result
 
 

--- a/test/test_drivers_eida50.py
+++ b/test/test_drivers_eida50.py
@@ -60,13 +60,15 @@ def test_dataset_navigator():
 
 
 def test_dataset_map_view():
+    store = Mock()
     settings = {
         "pattern": "",
     }
-    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("eida50", settings)
-    view = dataset.map_view(color_mapper)
-    view.render({})
+    view = dataset.map_view()
+    view.connect(store)
+    view.add_figure(bokeh.plotting.figure())
+    store.add_subscriber.assert_called()
 
 
 def test_navigator_pressures():

--- a/test/test_drivers_unified_model.py
+++ b/test/test_drivers_unified_model.py
@@ -13,10 +13,10 @@ def test_dataset_loader_pattern():
     settings = {
         "pattern": "*.nc",
     }
-    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view(color_mapper)
-    assert isinstance(view.loader, forest.drivers.unified_model.Loader)
+    view = dataset.map_view()
+    # Law of demeter violation
+    assert isinstance(view.image_view.loader, forest.drivers.unified_model.Loader)
 
 
 def test_navigator_use_database(tmpdir):
@@ -44,11 +44,11 @@ def test_loader_use_database(tmpdir):
         "locator": "database",
         "database_path": database_path,
     }
-    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view(color_mapper)
-    assert hasattr(view.loader.locator, "connection")
-    assert view.loader.locator.directory == "/replace"
+    view = dataset.map_view()
+    # Law of demeter violation
+    assert hasattr(view.image_view.loader.locator, "connection")
+    assert view.image_view.loader.locator.directory == "/replace"
 
 
 def test_view_render_state(tmpdir):
@@ -63,17 +63,18 @@ def test_view_render_state(tmpdir):
     settings = {
         "pattern": path,
     }
-    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view(color_mapper)
-    view.render({
+    view = dataset.map_view()
+    # Law of demeter violation
+    view.image_view.render({
         "initial_time": dt.datetime(2020, 1, 1),
         "valid_time": dt.datetime(2020, 1, 1),
         "variable": variable,
         "pressure": None,
         "pressures": []  # Needed by Loader.valid(state)
     })
-    assert len(view.image_sources[0].data["image"]) == 1
+    # Law of demeter violation
+    assert len(view.image_view.image_sources[0].data["image"]) == 1
 
 
 def test_load_image(tmpdir):

--- a/test/test_layer_pool.py
+++ b/test/test_layer_pool.py
@@ -9,7 +9,6 @@ import forest.view
 
 @pytest.fixture
 def factory():
-    color_mapper = bokeh.models.LinearColorMapper()
     name = "unified_model"
     settings = {"pattern": "*.nc"}
     dataset = forest.drivers.get_dataset(name, settings)
@@ -17,7 +16,6 @@ def factory():
     source_limits = Mock()
     opacity_slider = Mock()
     return forest.layers.Factory(dataset,
-                                 color_mapper,
                                  figures,
                                  source_limits,
                                  opacity_slider)

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -1,17 +1,16 @@
 import pytest
 import yaml
-import bokeh.models
 import forest.drivers
 from forest.drivers import rdt
 
 
 def test_build_loader_given_files():
     settings = {"pattern": "file_20190101T0000Z.nc"}
-    color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("unified_model", settings)
-    view = dataset.map_view(color_mapper)
-    assert isinstance(view.loader, forest.drivers.unified_model.Loader)
-    assert isinstance(view.loader.locator, forest.drivers.unified_model.Locator)
+    view = dataset.map_view()
+    # Law of demeter violation
+    assert isinstance(view.image_view.loader, forest.drivers.unified_model.Loader)
+    assert isinstance(view.image_view.loader.locator, forest.drivers.unified_model.Locator)
 
 
 def test_build_loader_given_rdt_file_type():


### PR DESCRIPTION
# Support multiple color mappers

De-couple imagery from a single color mapper. Intention here is to make `State` concept richer so that multiple collections of settings can be encoded

Closes #335 

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
