### PR TITLE
Python 3.6 dataclasses support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 
 env:
   matrix:
-    - PYTHON_VERSION="3.6" EXTRA_ARGS="--file requirements-py3.6.txt"
+    - PYTHON_VERSION="3.6" EXTRA_ARGS="--file requirements-py36.txt"
     - PYTHON_VERSION="3.7" EXTRA_ARGS=""
     - PYTHON_VERSION="3.8" EXTRA_ARGS=""
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 
 env:
   matrix:
-    - PYTHON_VERSION="3.6"
-    - PYTHON_VERSION="3.7"
-    - PYTHON_VERSION="3.8"
+    - PYTHON_VERSION="3.6" EXTRA_ARGS="--file requirements-py3.6.txt"
+    - PYTHON_VERSION="3.7" EXTRA_ARGS=""
+    - PYTHON_VERSION="3.8" EXTRA_ARGS=""
 
 git:
   # We need a deep clone so that we can compute the age of the files using their git history.
@@ -34,7 +34,7 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - echo "Install forest dependencies"
-  - conda install --quiet -n ${ENV_NAME} --file requirements.txt --file requirements-dev.txt
+  - conda install --quiet -n ${ENV_NAME} --file requirements.txt --file requirements-dev.txt ${EXTRA_ARGS}
 
   # Output debug info
   # -----------------

--- a/requirements-py36.txt
+++ b/requirements-py36.txt
@@ -1,0 +1,1 @@
+dataclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ pygrib
 libwebp=1.0.2  # Pin to prevent Travis issue
 xarray
 geojson
-dataclasses; python_version == '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pygrib
 libwebp=1.0.2  # Pin to prevent Travis issue
 xarray
 geojson
+dataclasses; python_version == '3.6'


### PR DESCRIPTION
# Dataclass support

Travis and requirements.txt changes needed to import dataclasses in Python3.6 only

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
