### PR TITLE
Refactor data limits

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.13.8'
+__version__ = '0.14.0'
 
 from .config import *
 from . import (

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -380,6 +380,12 @@ class UserLimits(Observable):
         self.inputs["low"].on_change("value", self.on_input_low)
         self.inputs["high"].on_change("value", self.on_input_high)
 
+        # RadioGroup for user/data limits
+        self.radio_group = bokeh.models.RadioGroup(
+            labels=["Use data limits", "Use user limits"],
+            active=0,
+            inline=True)
+
         self.checkboxes = {}
 
         # Checkbox fix data limits to user supplied limits
@@ -411,6 +417,9 @@ class UserLimits(Observable):
             bokeh.layouts.row(
                 self.inputs["source_low"],
                 self.inputs["source_high"],
+                width=widths["row"]),
+            bokeh.layouts.row(
+                self.radio_group,
                 width=widths["row"]),
             self.checkboxes["fixed"],
             self.checkboxes["invisible_min"],
@@ -455,12 +464,21 @@ class UserLimits(Observable):
             else:
                 self.checkboxes[key].active = []
 
-        if "high" in props:
-            self.inputs["high"].value = str(props["high"])
-            self.inputs["source_high"].value = str(props["high"])
-        if "low" in props:
-            self.inputs["low"].value = str(props["low"])
-            self.inputs["source_low"].value = str(props["low"])
+        # User limits
+        origin = "user"
+        attrs = props.get("limits", {}).get(origin, {})
+        if "high" in attrs:
+            self.inputs["high"].value = str(attrs["high"])
+        if "low" in attrs:
+            self.inputs["low"].value = str(attrs["low"])
+
+        # ColumnDataSource limits
+        origin = "column_data_source"
+        attrs = props.get("limits", {}).get(origin, {})
+        if "high" in attrs:
+            self.inputs["source_high"].value = str(attrs["high"])
+        if "low" in attrs:
+            self.inputs["source_low"].value = str(attrs["low"])
 
 
 def state_to_props(state):

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -363,8 +363,10 @@ class UserLimits(Observable):
     """User controlled color mapper limits"""
     def __init__(self):
         self.inputs = {
-            "low": bokeh.models.TextInput(title="User min:"),
-            "high": bokeh.models.TextInput(title="User max:"),
+            "low": bokeh.models.TextInput(title="User min:",
+                                          placeholder="Enter a number"),
+            "high": bokeh.models.TextInput(title="User max:",
+                                           placeholder="Enter a number"),
             "source_low": bokeh.models.TextInput(title="Data min:",
                                                  disabled=True),
             "source_high": bokeh.models.TextInput(title="Data max:",
@@ -427,10 +429,12 @@ class UserLimits(Observable):
         return self
 
     def on_input_low(self, attr, old, new):
-        self.notify(set_user_low(float(new)))
+        """Event-handler to set user low"""
+        self.notify(set_user_low(new))
 
     def on_input_high(self, attr, old, new):
-        self.notify(set_user_high(float(new)))
+        """Event-handler to set user high"""
+        self.notify(set_user_high(new))
 
     def on_invisible_min(self, attr, old, new):
         """Event-handler when invisible_min toggle is changed"""
@@ -566,9 +570,15 @@ class ColorPalette(Observable):
         origin = props.get("limits", {}).get("origin", "column_data_source")
         attrs = props.get("limits", {}).get(origin, {})
         if "low" in attrs:
-            self.color_mapper.low = attrs["low"]
+            try:
+                self.color_mapper.low = float(attrs["low"])
+            except ValueError:
+                pass
         if "high" in attrs:
-            self.color_mapper.high = attrs["high"]
+            try:
+                self.color_mapper.high = float(attrs["high"])
+            except ValueError:
+                pass
 
         invisible_min = props.get("invisible_min", False)
         if invisible_min:

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -350,7 +350,11 @@ class UserLimits(Observable):
     def __init__(self):
         self.inputs = {
             "low": bokeh.models.TextInput(title="Min:"),
-            "high": bokeh.models.TextInput(title="Max:")
+            "high": bokeh.models.TextInput(title="Max:"),
+            "source_low": bokeh.models.TextInput(title="Data min:",
+                                                 disabled=True),
+            "source_high": bokeh.models.TextInput(title="Data max:",
+                                                  disabled=True)
         }
         self.inputs["low"].on_change("value", self.on_input_low)
         self.inputs["high"].on_change("value", self.on_input_high)
@@ -375,9 +379,18 @@ class UserLimits(Observable):
             active=[])
         self.checkboxes["invisible_max"].on_change("active", self.on_invisible_max)
 
+        widths = {
+            "row": 310
+        }
         self.layout = bokeh.layouts.column(
-            self.inputs["low"],
-            self.inputs["high"],
+            bokeh.layouts.row(
+                self.inputs["low"],
+                self.inputs["high"],
+                width=widths["row"]),
+            bokeh.layouts.row(
+                self.inputs["source_low"],
+                self.inputs["source_high"],
+                width=widths["row"]),
             self.checkboxes["fixed"],
             self.checkboxes["invisible_min"],
             self.checkboxes["invisible_max"],
@@ -423,8 +436,10 @@ class UserLimits(Observable):
 
         if "high" in props:
             self.inputs["high"].value = str(props["high"])
+            self.inputs["source_high"].value = str(props["high"])
         if "low" in props:
             self.inputs["low"].value = str(props["low"])
+            self.inputs["source_low"].value = str(props["low"])
 
 
 def state_to_props(state):

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -573,10 +573,15 @@ class ColorPalette(Observable):
         if "numbers" in props:
             values = [str(n) for n in props["numbers"]]
             self.dropdowns["numbers"].menu = list(zip(values, values))
-        if "low" in props:
-            self.color_mapper.low = props["low"]
-        if "high" in props:
-            self.color_mapper.high = props["high"]
+
+        # Set color_mapper low/high from either user/data limits
+        origin = "column_data_source"
+        attrs = props.get("limits", {}).get(origin, {})
+        if "low" in attrs:
+            self.color_mapper.low = attrs["low"]
+        if "high" in attrs:
+            self.color_mapper.high = attrs["high"]
+
         invisible_min = props.get("invisible_min", False)
         if invisible_min:
             color = bokeh.colors.RGB(0, 0, 0, a=0)

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -101,6 +101,7 @@ from forest.rx import Stream
 from forest.db.util import autolabel
 
 
+SET_INVISIBLE = "SET_INVISIBLE"
 SET_PALETTE = "SET_PALETTE"
 SET_LIMITS = "SET_LIMITS"
 SET_LIMITS_ORIGIN = "SET_LIMITS_ORIGIN"
@@ -142,11 +143,6 @@ def set_source_limits(low, high):
             "payload": {"low": low, "high": high},
             "meta": {"origin": "column_data_source"}}
 
-def is_source_origin(action):
-    """Detect origin of set_limits action"""
-    origin = action.get("meta", {}).get("origin", "")
-    return origin == "column_data_source"
-
 
 def set_user_high(high):
     """Action to set user defined colorbar higher limit"""
@@ -169,11 +165,11 @@ def set_limits_origin(text):
 
 def set_invisible_min(flag):
     """Action to mask out data below colour bar limits"""
-    return {"kind": SET_LIMITS, "payload": {"invisible_min": flag}}
+    return {"kind": SET_INVISIBLE, "payload": {"invisible_min": flag}}
 
 def set_invisible_max(flag):
     """Action to mask out data below colour bar limits"""
-    return {"kind": SET_LIMITS, "payload": {"invisible_max": flag}}
+    return {"kind": SET_INVISIBLE, "payload": {"invisible_max": flag}}
 
 
 def reducer(state, action):
@@ -187,7 +183,7 @@ def reducer(state, action):
     """
     state = copy.deepcopy(state)
     kind = action["kind"]
-    if kind in [SET_PALETTE, SET_LIMITS]:
+    if kind in [SET_PALETTE, SET_INVISIBLE]:
         state["colorbar"] = state.get("colorbar", {})
         state["colorbar"].update(action["payload"])
     return state

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -194,6 +194,27 @@ def reducer(state, action):
     return state
 
 
+def limits_reducer(state, action):
+    state = copy.deepcopy(state)
+
+    # Do nothing if not column_data_source/user meta
+    if meta_origin(action) not in {"user", "column_data_source"}:
+        return state
+
+    # Build/traverse tree
+    node = state
+    keys = ("colorbar", "limits", meta_origin(action))
+    for key in keys:
+        node[key] = node.get(key, {})
+        node = node[key]
+    node.update(action["payload"])
+    return state
+
+
+def meta_origin(action):
+    return action.get("meta", {}).get("origin", "")
+
+
 def defaults():
     """Default color palette settings
 

--- a/forest/main.py
+++ b/forest/main.py
@@ -225,6 +225,7 @@ def main(argv=None):
             screen.reducer,
             tools.reducer,
             colors.reducer,
+            colors.limits_reducer,
             presets.reducer,
             tiles.reducer),
         initial_state=initial_state,

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -14,9 +14,9 @@ def listener():
     ({}, colors.set_palette_name("Accent"), {"colorbar": {"name": "Accent"}}),
     ({}, colors.set_palette_number(3), {"colorbar": {"number": 3}}),
     ({}, colors.set_palette_numbers([1, 2 ,3]), {"colorbar": {"numbers": [1, 2, 3]}}),
-    ({}, colors.set_user_high(100), {"colorbar": {"high": 100}}),
-    ({}, colors.set_user_low(0), {"colorbar": {"low": 0}}),
-    ({}, colors.set_source_limits(0, 100), {"colorbar": {"low": 0, "high": 100}}),
+    ({}, colors.set_user_high(100), {}),
+    ({}, colors.set_user_low(0), {}),
+    ({}, colors.set_source_limits(0, 100), {}),
     ({}, colors.set_colorbar({"key": "value"}), {"colorbar": {"key": "value"}}),
     ({}, colors.set_palette_names(["example"]), {"colorbar": {"names": ["example"]}}),
 ])

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -11,8 +11,6 @@ def listener():
 
 
 @pytest.mark.parametrize("state,action,expect", [
-    ({}, colors.set_fixed(True), {"colorbar": {"fixed": True}}),
-    ({}, colors.set_fixed(False), {"colorbar": {"fixed": False}}),
     ({}, colors.set_palette_name("Accent"), {"colorbar": {"name": "Accent"}}),
     ({}, colors.set_palette_number(3), {"colorbar": {"number": 3}}),
     ({}, colors.set_palette_numbers([1, 2 ,3]), {"colorbar": {"numbers": [1, 2, 3]}}),
@@ -73,7 +71,6 @@ def test_defaults():
         "numbers": colors.palette_numbers("Viridis"),
         "low": 0,
         "high": 1,
-        "fixed": False,
         "reverse": False,
         "invisible_min": False,
         "invisible_max": False
@@ -133,22 +130,6 @@ def test_middleware_given_inconsistent_number():
                 colors.palette_numbers("Viridis")),
             colors.set_palette_number(256),
             colors.set_palette_name("Viridis")]
-
-
-def test_middleware_given_fixed_swallows_source_limit_actions():
-    store = redux.Store(colors.reducer, middlewares=[
-        colors.palettes])
-    store.dispatch(colors.set_fixed(True))
-    action = colors.set_source_limits(0, 100)
-    assert list(colors.palettes(store, action)) == []
-    assert store.state == {"colorbar": {"fixed": True}}
-
-
-@pytest.mark.skip()
-def test_middleware_given_fixed_allows_source_limit_actions():
-    store = redux.Store(colors.reducer)
-    action = colors.set_source_limits(0, 100)
-    assert list(colors.palettes(store, action)) == [action]
 
 
 @pytest.mark.parametrize("name,expect", [
@@ -229,9 +210,6 @@ def test_color_palette_render_checkbox(props, active):
 
 
 @pytest.mark.parametrize("key,props,active", [
-    ("fixed", {}, []),
-    ("fixed", {"fixed": False}, []),
-    ("fixed", {"fixed": True}, [0]),
     ("invisible_min", {}, []),
     ("invisible_min", {"invisible_min": False}, []),
     ("invisible_min", {"invisible_min": True}, [0]),
@@ -247,20 +225,9 @@ def test_user_limits_render_checkboxes(key, props, active):
 
 def test_user_limits_render():
     user_limits = colors.UserLimits()
-    user_limits.render({"low": -1, "high": 1})
+    user_limits.render({"limits": {"user": {"low": -1, "high": 1}}})
     assert user_limits.inputs["low"].value == "-1"
     assert user_limits.inputs["high"].value == "1"
-
-
-@pytest.mark.parametrize("new,action", [
-    ([0], colors.set_fixed(True)),
-    ([], colors.set_fixed(False)),
-])
-def test_user_limits_on_fixed(listener, new, action):
-    user_limits = colors.UserLimits()
-    user_limits.add_subscriber(listener)
-    user_limits.on_checkbox_change(None, None, new)
-    listener.assert_called_once_with(action)
 
 
 @pytest.mark.parametrize("sources,low,high", [

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -27,6 +27,13 @@ def test_reducer(state, action, expect):
     assert expect == result
 
 
+def test_limits_reducer_origin():
+    text = "foo"
+    action = colors.set_limits_origin(text)
+    state = colors.limits_reducer({}, action)
+    assert state["colorbar"]["limits"]["origin"] == text
+
+
 def test_limits_reducer_user_low():
     number = 42
     action = colors.set_user_low(number)

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -27,6 +27,31 @@ def test_reducer(state, action, expect):
     assert expect == result
 
 
+def test_limits_reducer_user_low():
+    number = 42
+    action = colors.set_user_low(number)
+    state = colors.limits_reducer({}, action)
+    origin = "user"
+    assert state["colorbar"]["limits"][origin]["low"] == number
+
+
+def test_limits_reducer_user_high():
+    number = 42
+    action = colors.set_user_high(number)
+    state = colors.limits_reducer({}, action)
+    origin = "user"
+    assert state["colorbar"]["limits"][origin]["high"] == number
+
+
+def test_limits_reducer_source():
+    low, high = 42, 1729
+    action = colors.set_source_limits(low, high)
+    state = colors.limits_reducer({}, action)
+    origin = "column_data_source"
+    assert state["colorbar"]["limits"][origin]["low"] == low
+    assert state["colorbar"]["limits"][origin]["high"] == high
+
+
 def test_reducer_immutable_state():
     state = {"colorbar": {"number": 1}}
     colors.reducer(state, colors.set_palette_number(3))


### PR DESCRIPTION
# Separate Data/User limits user interface

Simplify how a user selects limits by displaying data limits and including a radio group to toggle between user defined and data defined limits

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
