### PR TITLE
add wildcard to fix saf.Dataset TypeError

### DIFF
--- a/forest/drivers/saf.py
+++ b/forest/drivers/saf.py
@@ -33,7 +33,8 @@ class Dataset:
                  label=None,
                  pattern=None,
                  locator=None,
-                 database_path=None):
+                 database_path=None,
+                 **kwargs):
         self.label = label
         self.pattern = pattern
         self.locator = Locator(self.pattern)


### PR DESCRIPTION
# SAF Dataset kwargs

Missing wildcard kwargs in `saf.Dataset`

Closes #346 

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
