### PR TITLE
Populate modal select widgets with CustomJS

### DIFF
--- a/forest/dimension.py
+++ b/forest/dimension.py
@@ -1,0 +1,24 @@
+"""Dimension information relating to datasets"""
+import copy
+
+
+SET_VARIABLES = "DIMENSION_SET_VARIABLES"
+
+
+def set_variables(label, values):
+    """Action to set variables related to dataset"""
+    return {"kind": SET_VARIABLES,
+            "payload": {"label": label, "values": values}}
+
+
+def reducer(state, action):
+    """Encode dimension information into state"""
+    state = copy.deepcopy(state)
+    kind = action["kind"]
+    if kind == SET_VARIABLES:
+        node = state
+        for key in ("dimension", action["payload"]["label"]):
+            node[key] = node.get(key, {})
+            node = node[key]
+        node["variables"] = action["payload"]["values"]
+    return state

--- a/forest/main.py
+++ b/forest/main.py
@@ -6,6 +6,7 @@ import os
 from forest import _profile as profile
 from forest import (
         drivers,
+        dimension,
         screen,
         tools,
         series,
@@ -185,7 +186,8 @@ def main(argv=None):
             colors.reducer,
             colors.limits_reducer,
             presets.reducer,
-            tiles.reducer),
+            tiles.reducer,
+            dimension.reducer),
         initial_state=initial_state,
         middlewares=middlewares)
 
@@ -276,6 +278,12 @@ def main(argv=None):
             store.dispatch(forest.layers.save_layer(0, spec))
             break
         break
+
+    # Set variable dimensions (needed by modal dialogue)
+    for label, dataset in datasets.items():
+        pattern = label_to_pattern[label]
+        values = navigator.variables(pattern)
+        store.dispatch(dimension.set_variables(label, values))
 
     # Select web map tiling
     if config.use_web_map_tiles:

--- a/forest/static/script.js
+++ b/forest/static/script.js
@@ -4,3 +4,20 @@ let openId = function(id) {
 let closeId = function(id) {
     document.getElementById(id).style.width = "0";
 }
+
+let forest = (function() {
+    let ns = {};
+
+    // Populate variable options from dataset value
+    ns.link_selects = function(dataset_select, variable_select, source) {
+        let label = dataset_select.value;
+        if (label !== "") {
+            let index = source.data['datasets'].indexOf(label)
+            let defaults = ["Please specify"];
+            variable_select.options = defaults.concat(
+                source.data['variables'][index]);
+        }
+    }
+
+    return ns;
+})();

--- a/test/test_dimension.py
+++ b/test/test_dimension.py
@@ -1,0 +1,9 @@
+import forest.dimension
+
+
+def test_reducer_set_variables():
+    label = "dataset_label"
+    variables = ["foo", "bar"]
+    action = forest.dimension.set_variables(label, variables)
+    state = forest.dimension.reducer({}, action)
+    assert state["dimension"][label]["variables"] == variables


### PR DESCRIPTION
# Populate variable options from dataset choice

- Fix issue over-looked during previous #294 change variable options with respect to dataset choice

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
