### PR TITLE
Rx distinct comparator

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.15.1'
+__version__ = '0.15.2'
 
 from .config import *
 from . import (

--- a/forest/rx.py
+++ b/forest/rx.py
@@ -57,6 +57,7 @@ class Stream(Observable):
                     y = x  # Important: must be before notify() to prevent recursion
                     stream.notify(x)
                     called = True
+                    return
                 if comparator is None:
                     not_same = x != y
                 else:

--- a/forest/rx.py
+++ b/forest/rx.py
@@ -40,9 +40,10 @@ class Stream(Observable):
         self.add_subscriber(callback)
         return stream
 
-    def distinct(self):
+    def distinct(self, comparator=None):
         """Remove repeated items
 
+        :param comparator: f(x, y) that returns True if x == y
         :returns: new stream with duplicate events removed
         """
         stream = Stream()
@@ -56,7 +57,11 @@ class Stream(Observable):
                     y = x  # Important: must be before notify() to prevent recursion
                     stream.notify(x)
                     called = True
-                if x != y:
+                if comparator is None:
+                    not_same = x != y
+                else:
+                    not_same = not comparator(x, y)
+                if not_same:
                     y = x  # Important: must be before notify() to prevent recursion
                     stream.notify(x)
             return callback

--- a/test/test_rx.py
+++ b/test/test_rx.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock, sentinel, call
+import forest.rx
+
+
+def test_distinct_given_true_comparator():
+    comparator = Mock(return_value=True)
+    listener = Mock()
+    stream = forest.rx.Stream()
+    stream.distinct(comparator).map(listener)
+    stream.notify(sentinel.first)
+    stream.notify(sentinel.second)
+    listener.assert_called_once_with(sentinel.first)
+
+
+def test_distinct_given_false_comparator():
+    comparator = Mock(return_value=False)
+    listener = Mock()
+    stream = forest.rx.Stream()
+    stream.distinct(comparator).map(listener)
+    stream.notify(sentinel.first)
+    stream.notify(sentinel.second)
+    assert listener.call_count == 2, "listener should only be called twice"
+    listener.assert_has_calls([
+        call(sentinel.first),
+        call(sentinel.second)
+    ])


### PR DESCRIPTION
# Add support for Stream.distinct(comparator)

Useful for components to watch subsets of state and to decide for themselves what constitutes duplicate state

- Fixes bug in `stream.distinct` that calls listeners twice the first time through the pipeline

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
