### PR TITLE
Refactor colorspec

### DIFF
--- a/forest/colors.py
+++ b/forest/colors.py
@@ -99,6 +99,49 @@ import numpy as np
 from forest.observe import Observable
 from forest.rx import Stream
 from forest.db.util import autolabel
+from dataclasses import dataclass
+
+
+@dataclass
+class ColorSpec:
+    """Specifies color mapper settings"""
+    name: str = "Greys"
+    number: int = 256
+    reverse: bool = False
+    low: float = 0.
+    low_visible: bool = True
+    high: float = 1.
+    high_visible: bool = True
+
+    @property
+    def palette(self):
+        if self.reverse:
+            step = -1
+        else:
+            step = 1
+        return bokeh.palettes.all_palettes[self.name][self.number][::step]
+
+    @property
+    def high_color(self):
+        if self.high_visible:
+            return None
+        else:
+            return bokeh.colors.RGB(0, 0, 0, a=0)
+
+    @property
+    def low_color(self):
+        if self.low_visible:
+            return None
+        else:
+            return bokeh.colors.RGB(0, 0, 0, a=0)
+
+    def apply(self, color_mapper):
+        """Helper to apply settings to color_mapper"""
+        color_mapper.palette = self.palette
+        color_mapper.low = self.low
+        color_mapper.low_color = self.low_color
+        color_mapper.high = self.high
+        color_mapper.high_color = self.high_color
 
 
 SET_INVISIBLE = "SET_INVISIBLE"

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -14,6 +14,41 @@ from forest import (
         geo,
         locate,
         view)
+from dataclasses import dataclass
+
+
+@dataclass
+class ColorSpec:
+    """Specifies color mapper settings"""
+    name: str = "Greys"
+    number: int = 256
+    reverse: bool = False
+    low: float = 0.
+    low_visible: bool = True
+    high: float = 1.
+    high_visible: bool = True
+
+    @property
+    def palette(self):
+        if self.reverse:
+            step = -1
+        else:
+            step = 1
+        return bokeh.palettes.all_palettes[self.name][self.number][::step]
+
+    @property
+    def high_color(self):
+        if self.high_visible:
+            return None
+        else:
+            return bokeh.colors.RGB(0, 0, 0, a=0)
+
+    @property
+    def low_color(self):
+        if self.low_visible:
+            return None
+        else:
+            return bokeh.colors.RGB(0, 0, 0, a=0)
 
 
 ENGINE = "h5netcdf"

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -10,45 +10,11 @@ from functools import lru_cache
 from forest.exceptions import FileNotFound, IndexNotFound
 from forest.old_state import old_state, unique
 import forest.util
+import forest.colors
 from forest import (
         geo,
         locate,
         view)
-from dataclasses import dataclass
-
-
-@dataclass
-class ColorSpec:
-    """Specifies color mapper settings"""
-    name: str = "Greys"
-    number: int = 256
-    reverse: bool = False
-    low: float = 0.
-    low_visible: bool = True
-    high: float = 1.
-    high_visible: bool = True
-
-    @property
-    def palette(self):
-        if self.reverse:
-            step = -1
-        else:
-            step = 1
-        return bokeh.palettes.all_palettes[self.name][self.number][::step]
-
-    @property
-    def high_color(self):
-        if self.high_visible:
-            return None
-        else:
-            return bokeh.colors.RGB(0, 0, 0, a=0)
-
-    @property
-    def low_color(self):
-        if self.low_visible:
-            return None
-        else:
-            return bokeh.colors.RGB(0, 0, 0, a=0)
 
 
 ENGINE = "h5netcdf"

--- a/forest/drivers/eida50.py
+++ b/forest/drivers/eida50.py
@@ -10,7 +10,6 @@ from functools import lru_cache
 from forest.exceptions import FileNotFound, IndexNotFound
 from forest.old_state import old_state, unique
 import forest.util
-import forest.colors
 from forest import (
         geo,
         locate,

--- a/test/test_color_spec.py
+++ b/test/test_color_spec.py
@@ -1,0 +1,11 @@
+import bokeh.models
+import forest.colors
+
+
+def test_colorspec_apply():
+    color_mapper = bokeh.models.LinearColorMapper()
+    low, high = 42, 137
+    spec = forest.colors.ColorSpec(low=low, high=high)
+    spec.apply(color_mapper)
+    assert color_mapper.low == low
+    assert color_mapper.high == high


### PR DESCRIPTION
# A dataclass to hold ColorMapper settings

A step towards color_mapper state, but also a good idea in general

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
