### PR TITLE
Single reducer

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -27,7 +27,9 @@ __version__ = '0.15.2'
 
 from .config import *
 from . import (
+        actions,
         redux,
         tutorial)
 from .db import Database
 from .keys import *
+from .reducer import reducer

--- a/forest/actions.py
+++ b/forest/actions.py
@@ -1,0 +1,8 @@
+"""Collection of actions"""
+
+
+NO_ACTION = "NO_ACTION"
+
+
+def no_action():
+    return {"kind": NO_ACTION}

--- a/forest/components/tiles.py
+++ b/forest/components/tiles.py
@@ -90,12 +90,14 @@ def set_label_visible(value: bool) -> Action:
 def reducer(state: State, action: Action) -> State:
     """Reducer to handle web map tiling settings"""
     state = copy.deepcopy(state)
-    tree = state.get("tile", {})
-    if action["kind"] == SET_TILE:
-        tree["name"] = action["payload"]
-    elif action["kind"] == SET_LABEL_VISIBLE:
-        tree["labels"] = action["payload"]
-    state["tile"] = tree
+    kind = action["kind"]
+    if kind in [SET_TILE, SET_LABEL_VISIBLE]:
+        tree = state.get("tile", {})
+        if kind == SET_TILE:
+            tree["name"] = action["payload"]
+        elif kind == SET_LABEL_VISIBLE:
+            tree["labels"] = action["payload"]
+        state["tile"] = tree
     return state
 
 

--- a/forest/main.py
+++ b/forest/main.py
@@ -178,16 +178,7 @@ def main(argv=None):
         navigator,
     ]
     store = redux.Store(
-        redux.combine_reducers(
-            db.reducer,
-            layers.reducer,
-            screen.reducer,
-            tools.reducer,
-            colors.reducer,
-            colors.limits_reducer,
-            presets.reducer,
-            tiles.reducer,
-            dimension.reducer),
+        forest.reducer,
         initial_state=initial_state,
         middlewares=middlewares)
 

--- a/forest/reducer.py
+++ b/forest/reducer.py
@@ -1,0 +1,24 @@
+"""Reducer"""
+from forest import (
+    redux,
+    db,
+    layers,
+    screen,
+    tools,
+    colors,
+    presets,
+    dimension)
+from forest.components import (
+    tiles)
+
+
+reducer = redux.combine_reducers(
+            db.reducer,
+            layers.reducer,
+            screen.reducer,
+            tools.reducer,
+            colors.reducer,
+            colors.limits_reducer,
+            presets.reducer,
+            tiles.reducer,
+            dimension.reducer)

--- a/test/test_reducer.py
+++ b/test/test_reducer.py
@@ -1,0 +1,7 @@
+import forest
+
+
+def test_reducer():
+    state = {}
+    action = forest.actions.no_action()
+    assert forest.reducer(state, action) == {}


### PR DESCRIPTION
# One reducer to rule them all

Easier to reason about redux pattern if there is only one reducer and a module containing all possible actions

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
