### PR TITLE
Convert Modal UI to container for other Views

### DIFF
--- a/forest/components/modal.py
+++ b/forest/components/modal.py
@@ -4,8 +4,50 @@ from forest.observe import Observable
 from forest import layers
 
 
-class Modal(Observable):
+class Modal:
     """Modal component"""
+    def __init__(self, view=None):
+        if view is None:
+            view = Default()
+        self.view = view
+        self.layout = bokeh.layouts.column(
+            self.view.layout,
+            name="modal",
+            sizing_mode="stretch_width")
+
+    def connect(self, store):
+        return self.view.connect(store)
+
+
+class Tabbed:
+    """Tabbed user interface"""
+    def __init__(self):
+        self.views = {}
+        self.views["default"] = Default()
+        self.views["settings"] = Settings()
+        self.layout = bokeh.models.Tabs(tabs=[
+            bokeh.models.Panel(
+                child=self.views["default"].layout,
+                title="Layer"
+            ),
+            bokeh.models.Panel(
+                child=self.views["settings"].layout,
+                title="Settings"
+            )])
+
+    def connect(self, store):
+        self.views["default"].connect(store)
+        return self
+
+
+class Settings:
+    """MapView settings"""
+    def __init__(self):
+        self.layout = bokeh.models.Div(text="<h1>Hello, World!</h1>")
+
+
+class Default(Observable):
+    """Standard modal dialogue user interface"""
     def __init__(self):
         self.div = bokeh.models.Div(text="Add layer",
                                css_classes=["custom"],
@@ -68,7 +110,6 @@ class Modal(Observable):
             self.selects["dataset"],
             self.selects["variable"],
             bokeh.layouts.row(*buttons, sizing_mode="stretch_width"),
-            name="modal",
             sizing_mode="stretch_width")
         super().__init__()
 

--- a/forest/main.py
+++ b/forest/main.py
@@ -246,7 +246,11 @@ def main(argv=None):
     controls.connect(store)
 
     # Add support for a modal dialogue
-    modal = forest.components.Modal()
+    if config.features["multiple_colorbars"]:
+        view = forest.components.modal.Tabbed()
+    else:
+        view = forest.components.modal.Default()
+    modal = forest.components.Modal(view=view)
     modal.connect(store)
 
     # Set default time series visibility

--- a/test/test_components_modal.py
+++ b/test/test_components_modal.py
@@ -2,16 +2,16 @@ import forest.components
 
 
 def test_render():
-    view = forest.components.Modal()
+    modal = forest.components.Modal()
     state = {
         "patterns": [("A", None), ("B", None)]
     }
-    view.render(state)
-    assert view.selects["dataset"].options == ["A", "B"]
+    modal.view.render(state)
+    assert modal.view.selects["dataset"].options == ["A", "B"]
 
 
 def test_render_edit_mode():
-    view = forest.components.Modal()
+    modal = forest.components.Modal()
     state = {
         "layers": {
             "mode": {
@@ -25,5 +25,5 @@ def test_render_edit_mode():
             }
         }
     }
-    view.render(state)
-    assert view.inputs["name"].value == "Label-5"
+    modal.view.render(state)
+    assert modal.view.inputs["name"].value == "Label-5"


### PR DESCRIPTION
# Extend modal UI to allow Settings tab

Modal UI converted to be a container for nested components

**Note::** Behind feature toggle `"multiple_colorbars"`

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
