### PR TITLE
Feature multicolor settings

### DIFF
--- a/forest/components/modal.py
+++ b/forest/components/modal.py
@@ -1,5 +1,6 @@
 import bokeh.models
 import bokeh.layouts
+import forest.colors
 from forest.observe import Observable
 from forest import layers
 
@@ -37,13 +38,25 @@ class Tabbed:
 
     def connect(self, store):
         self.views["default"].connect(store)
+        self.views["settings"].connect(store)
         return self
 
 
 class Settings:
     """MapView settings"""
     def __init__(self):
-        self.layout = bokeh.models.Div(text="<h1>Hello, World!</h1>")
+        self.views = {}
+        self.views["color_palette"] = forest.colors.ColorPalette()
+        self.views["user_limits"] = forest.colors.UserLimits()
+        self.layout = bokeh.layouts.column(
+            self.views["color_palette"].layout,
+            self.views["user_limits"].layout
+        )
+
+    def connect(self, store):
+        self.views["color_palette"].connect(store)
+        self.views["user_limits"].connect(store)
+        return self
 
 
 class Default(Observable):

--- a/forest/main.py
+++ b/forest/main.py
@@ -233,7 +233,8 @@ def main(argv=None):
         tile_picker.connect(store)
 
     # Connect color palette controls
-    color_palette = colors.ColorPalette(color_mapper).connect(store)
+    colors.ColorMapperView(color_mapper).connect(store)
+    color_palette = colors.ColorPalette().connect(store)
 
     # Connect limit controllers to store
     user_limits = colors.UserLimits().connect(store)

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -81,14 +81,13 @@ def test_defaults():
 
 def test_color_controls():
     color_mapper = bokeh.models.LinearColorMapper()
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorMapperView(color_mapper)
     controls.render({"name": "Accent", "number": 3})
     assert color_mapper.palette == ['#7fc97f', '#beaed4', '#fdc086']
 
 
 def test_controls_on_name(listener):
-    color_mapper = bokeh.models.LinearColorMapper()
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorPalette()
     controls.add_subscriber(listener)
     controls.on_number(None, None, 5)
     listener.assert_called_once_with(colors.set_palette_number(5))
@@ -143,16 +142,14 @@ def test_palette_numbers(name, expect):
 
 
 def test_controls_on_number(listener):
-    color_mapper = bokeh.models.LinearColorMapper()
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorPalette()
     controls.add_subscriber(listener)
     controls.on_number(None, None, 5)
     listener.assert_called_once_with(colors.set_palette_number(5))
 
 
 def test_controls_on_reverse(listener):
-    color_mapper = bokeh.models.LinearColorMapper()
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorPalette()
     controls.add_subscriber(listener)
     controls.on_reverse(None, None, [0])
     listener.assert_called_once_with(colors.set_reverse(True))
@@ -165,15 +162,13 @@ def test_controls_on_reverse(listener):
     ("names", {"name": "Blues", "number": 5}, "Blues")
 ])
 def test_controls_render_label(key, props, label):
-    color_mapper = bokeh.models.LinearColorMapper()
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorPalette()
     controls.render(props)
     assert controls.dropdowns[key].label == label
 
 
 def test_controls_render_sets_menu():
-    color_mapper = bokeh.models.LinearColorMapper()
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorPalette()
     names = ["A", "B"]
     numbers = [1, 2]
     props = {"names": names, "numbers": numbers}
@@ -193,7 +188,7 @@ def test_controls_render_sets_menu():
     ])
 def test_controls_render_palette(props, palette):
     color_mapper = bokeh.models.LinearColorMapper()
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorMapperView(color_mapper)
     controls.render(props)
     assert color_mapper.palette == palette
 
@@ -204,8 +199,7 @@ def test_controls_render_palette(props, palette):
     ({"reverse": True}, [0]),
 ])
 def test_color_palette_render_checkbox(props, active):
-    color_mapper = bokeh.models.LinearColorMapper()
-    color_palette = colors.ColorPalette(color_mapper)
+    color_palette = colors.ColorPalette()
     color_palette.render(props)
     assert color_palette.checkbox.active == active
 
@@ -257,9 +251,8 @@ def test_remove_source():
 
 
 def test_render_called_once_with_two_identical_settings():
-    color_mapper = bokeh.models.LinearColorMapper()
     store = redux.Store(colors.reducer)
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorPalette()
     controls.render = unittest.mock.Mock()
     controls.connect(store)
     for action in [
@@ -271,12 +264,11 @@ def test_render_called_once_with_two_identical_settings():
 
 def test_render_called_once_with_non_relevant_settings():
     """Render should only happen when relevant state changes"""
-    color_mapper = bokeh.models.LinearColorMapper()
     store = redux.Store(
             redux.combine_reducers(
                 db.reducer,
                 colors.reducer))
-    controls = colors.ColorPalette(color_mapper)
+    controls = colors.ColorPalette()
     controls.render = unittest.mock.Mock()
     controls.connect(store)
     for action in [


### PR DESCRIPTION
# Separate color_mapper settings UI from View

- `ColorPalette` contains widgets to set color_mapper settings in state
- `ColorMapperView` reactively sets the `color_mapper` used by all `MapViews`
- `forest.components.modal.Settings` updated to use `forest.colors.ColorPalette`

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
