### PR TITLE
Test colors/layer actions

### DIFF
--- a/forest/actions.py
+++ b/forest/actions.py
@@ -1,4 +1,11 @@
 """Collection of actions"""
+from forest.colors import (
+    set_palette_name,
+    set_user_high
+)
+from forest.layers import (
+    save_layer
+)
 
 
 NO_ACTION = "NO_ACTION"

--- a/test/test_reducer.py
+++ b/test/test_reducer.py
@@ -1,7 +1,46 @@
+import pytest
 import forest
 
 
-def test_reducer():
-    state = {}
-    action = forest.actions.no_action()
-    assert forest.reducer(state, action) == {}
+@pytest.mark.parametrize("state,action,expect", [
+    pytest.param(
+        {},
+        forest.actions.no_action(),
+        {},
+        id="no_action"
+    ),
+    pytest.param(
+        {},
+        forest.actions.set_palette_name("Accent"),
+        {
+            "colorbar": {
+                "name": "Accent"
+            }
+        },
+        id="set_palette_name"),
+    pytest.param(
+        {},
+        forest.actions.set_user_high(100),
+        {
+            "colorbar": {
+                "limits": {
+                    "user": {"high": 100}
+                }
+            }
+        },
+        id="set_palette_name"),
+    pytest.param(
+        {},
+        forest.actions.save_layer(0, {"key": "value"}),
+        {
+            "layers": {
+                "index": {
+                    0: {"key": "value"}
+                }
+            }
+        },
+        id="save_layer"
+    )
+])
+def test_reducer(state, action, expect):
+    assert forest.reducer(state, action) == expect


### PR DESCRIPTION
# Color/Layer actions

The modal dialogue saves all settings at once, using `on_save` and middleware to generate `save_layer` actions. This is distinct from the behaviour of colors.py that has very granular actions for each color palette adjustment

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
