### PR TITLE
Extract SaveEdit buttons in Modal

### DIFF
--- a/test/test_components_modal.py
+++ b/test/test_components_modal.py
@@ -6,8 +6,8 @@ def test_render():
     state = {
         "patterns": [("A", None), ("B", None)]
     }
-    modal.view.render(state)
-    assert modal.view.selects["dataset"].options == ["A", "B"]
+    modal.view.views["layer"].render(state)
+    assert modal.view.views["layer"].selects["dataset"].options == ["A", "B"]
 
 
 def test_render_edit_mode():
@@ -25,5 +25,5 @@ def test_render_edit_mode():
             }
         }
     }
-    modal.view.render(state)
-    assert modal.view.inputs["name"].value == "Label-5"
+    modal.view.views["layer"].render(state)
+    assert modal.view.views["layer"].inputs["name"].value == "Label-5"


### PR DESCRIPTION
# Extract SaveEdit component

Make it easier to support layer color_mapper settings by separating save/edit concerns from UI layout.

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
