### PR TITLE
Add ColorSpec as field of LayerSpec

### DIFF
--- a/forest/layers.py
+++ b/forest/layers.py
@@ -17,6 +17,7 @@ from typing import Iterable, List
 from forest import rx
 from forest.redux import Action, State, Store
 from forest.observe import Observable
+from forest import colors
 import forest.drivers
 import forest.view
 
@@ -487,6 +488,11 @@ class LayerSpec:
     dataset: str = ""
     variable: str = ""
     active: List[int] = field(default_factory=list)
+    color_spec: colors.ColorSpec = colors.ColorSpec()
+
+    def __post_init__(self):
+        if isinstance(self.color_spec, dict):
+            self.color_spec = colors.ColorSpec(**self.color_spec)
 
 
 class Gallery:

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -2,7 +2,21 @@ import pytest
 from unittest.mock import Mock, sentinel, call
 import bokeh.plotting
 import numpy as np
+import forest.layers
+import forest.colors
 from forest import layers, redux
+
+
+def test_layer_spec():
+    color_spec = forest.colors.ColorSpec(name="Accent")
+    layer_spec = forest.layers.LayerSpec(color_spec=color_spec)
+    assert layer_spec.color_spec.name == "Accent"
+
+
+def test_layer_spec_given_dict():
+    color_spec = {"name": "Accent"}
+    layer_spec = forest.layers.LayerSpec(color_spec=color_spec)
+    assert layer_spec.color_spec.name == "Accent"
 
 
 @pytest.mark.parametrize("action,expect", [


### PR DESCRIPTION
# Add ColorSpec as property of LayerSpec

To ease rendering of Layers in a future PR

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
