### PR TITLE
Add MapView and ColorView to render ColorSpec

### DIFF
--- a/forest/components/modal.py
+++ b/forest/components/modal.py
@@ -110,7 +110,12 @@ class Settings:
     def settings(self):
         # TODO: Replace with actual UI values, need to extend LayerSpec to
         #       support ColorSpec or an equivalent pointer to ColorSpec
-        return {}
+        return {
+            "color_spec": {
+                "name": "Accent",
+                "number": 3
+            }
+        }
 
     def connect(self, store):
         self.views["color_palette"].connect(store)

--- a/forest/config.py
+++ b/forest/config.py
@@ -77,7 +77,7 @@ class Config(object):
     @property
     def features(self):
         """Dict of user-defined feature toggles"""
-        d = defaultdict(lambda: True)
+        d = defaultdict(lambda: False)
         d.update(self.data.get("features", {}))
         return d
 

--- a/forest/data.py
+++ b/forest/data.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 try:
     import cartopy
 except ImportError:
@@ -30,6 +31,7 @@ DISPUTED = {
     "ys": []
 }
 AUTO_SHUTDOWN = False
+FEATURE_FLAGS = defaultdict(lambda: False)
 
 def on_server_loaded():
     global DISPUTED

--- a/forest/drivers/unified_model.py
+++ b/forest/drivers/unified_model.py
@@ -15,6 +15,7 @@ from forest import (
     view)
 from forest.exceptions import SearchFail, PressuresNotFound
 from forest.drivers import gridded_forecast
+import bokeh.models
 try:
     import iris
 except ImportError:
@@ -51,9 +52,18 @@ class Dataset:
             return Navigator(self.pattern)
 
     def map_view(self, color_mapper):
-        return view.UMView(Loader(self.label,
-                                  self.pattern,
-                                  self.locator), color_mapper)
+        # TODO: Use ColorSpec and unique LinearColorMapper in future
+        if forest.data.FEATURE_FLAGS["multiple_colorbars"]:
+            color_mapper = bokeh.models.LinearColorMapper()
+            color_view = view.ColorView(color_mapper)
+            um_view = view.UMView(Loader(self.label,
+                                         self.pattern,
+                                         self.locator), color_mapper)
+            return view.MapView(um_view, color_view)
+        else:
+            return view.UMView(Loader(self.label,
+                                      self.pattern,
+                                      self.locator), color_mapper)
 
 
 class Navigator:

--- a/forest/layers.py
+++ b/forest/layers.py
@@ -548,7 +548,8 @@ class Gallery:
             layer_state = {}
             layer_state.update(state)
             if spec.variable != "":
-                layer_state.update(variable=spec.variable)
+                layer_state.update(variable=spec.variable,
+                                   color_spec=spec.color_spec)
             layer.render(layer_state)
 
             used_layers[key].append(layer)

--- a/forest/main.py
+++ b/forest/main.py
@@ -44,6 +44,9 @@ def main(argv=None):
                     os.environ,
                     args.variables))
 
+    # Feature toggles
+    data.FEATURE_FLAGS = config.features
+
     # Full screen map
     viewport = config.default_viewport
     x_range, y_range = geo.web_mercator(

--- a/forest/view.py
+++ b/forest/view.py
@@ -17,6 +17,34 @@ class AbstractMapView(ABC):
         pass
 
 
+class MapView(AbstractMapView):
+    """Extend UMView to support color_mapper"""
+    def __init__(self, um_view, color_view):
+        self.um_view = um_view
+        self.color_view = color_view
+
+    @property
+    def image_sources(self):
+        return self.um_view.image_sources
+
+    def add_figure(self, figure):
+        return self.um_view.add_figure(figure)
+
+    def render(self, state):
+        self.color_view.render(state)
+        self.um_view.render(state)
+
+
+class ColorView:
+    """Applies ColorSpec to bokeh.models.LinearColorMapper"""
+    def __init__(self, color_mapper):
+        self.color_mapper = color_mapper
+
+    def render(self, state):
+        if "color_spec" in state:
+            state["color_spec"].apply(self.color_mapper)
+
+
 class UMView(AbstractMapView):
     def __init__(self, loader, color_mapper, use_hover_tool=True):
         self.loader = loader

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -211,8 +211,8 @@ def test_config_parser_use_web_map_tiles(data, expect):
 
 
 @pytest.mark.parametrize("data,expect", [
-    ({}, True),
-    ({"features": {"example": False}}, False),
+    ({}, False),
+    ({"features": {"example": True}}, True),
 ])
 def test_config_parser_features(data, expect):
     config = forest.config.Config(data)


### PR DESCRIPTION
# Add ColorMapper per MapView

- Turn `forest.data.FEATURES` toggles to `False` if not specified. Protest work in progress features from being used
- Add `MapView` and `ColorView` classes to apply `ColorSpec` on `render`

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
