### PR TITLE
Add reverse preview

### DIFF
--- a/forest/colors.py
+++ b/forest/colors.py
@@ -772,13 +772,21 @@ class ColorPaletteJS:
         self.selects["name"].on_change("value", self.on_preview)
         self.selects["number"].on_change("value", self.on_preview)
 
+        # Reverse checkbox
+        self.checkboxes = {}
+        self.checkboxes["reverse"] = bokeh.models.CheckboxGroup(
+            labels=["Reverse"],
+            active=[])
+        self.checkboxes["reverse"].on_change("active", self.on_preview)
+
         self.layout = bokeh.layouts.column(
             bokeh.models.Div(text="Color palette:",
                              width=self.widths["div"]),
             self.figure,
             bokeh.layouts.row(
                 self.selects["name"],
-                self.selects["number"]))
+                self.selects["number"]),
+            self.checkboxes["reverse"])
 
     def on_preview(self, attr, old, new):
         spec = ColorSpec(**self.props())
@@ -793,12 +801,17 @@ class ColorPaletteJS:
         for key, select in self.selects.items():
             if select.value is not None:
                 _props[key] = select.value
+        _props["reverse"] = len(self.checkboxes["reverse"].active) == 1
         return _props
 
     def render(self, props):
         for key, select in self.selects.items():
             if key in props:
                 select.value = str(props[key])
+        self.checkboxes["reverse"].active = {
+            True: [0],
+            False: []
+        }[props.get("reverse", False)]
 
 
 class ColorPalette(Observable):


### PR DESCRIPTION
# Add support for reverse to multiple colorbars

- Add reverse support

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
