### PR TITLE
add extras_require for conda-forge

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.15.3'
+__version__ = '0.15.4'
 
 from .config import *
 from . import (

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,11 @@ setuptools.setup(
         },
         test_suite="test",
         tests_require=load("requirements-dev.txt"),
+        extras_require={
+            ':python_version == "3.6"': [
+                "dataclasses"
+            ]
+        },
         entry_points={
             'console_scripts': [
                 'forest=forest.cli.main:main',


### PR DESCRIPTION
# Conda feedstock recipe

Python3.6 builds are failing across all operating systems in `conda-forge`

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
