### PR TITLE
Migrate bokeh 2.0.2

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.15.5'
+__version__ = '0.15.6'
 
 from .config import *
 from . import (

--- a/forest/colors.py
+++ b/forest/colors.py
@@ -821,8 +821,8 @@ class ColorPalette(Observable):
             "names": bokeh.models.Dropdown(label="Palettes"),
             "numbers": bokeh.models.Dropdown(label="N")
         }
-        self.dropdowns["names"].on_change("value", self.on_name)
-        self.dropdowns["numbers"].on_change("value", self.on_number)
+        self.dropdowns["names"].on_click(self.on_name)
+        self.dropdowns["numbers"].on_click(self.on_number)
 
         self.checkbox = bokeh.models.CheckboxGroup(
             labels=["Reverse"],
@@ -849,13 +849,13 @@ class ColorPalette(Observable):
             "reverse": len(self.checkbox.active) == 1
         }
 
-    def on_name(self, attr, old, new):
+    def on_name(self, event):
         """Event-handler when a palette name is selected"""
-        self.notify(set_palette_name(new))
+        self.notify(set_palette_name(event.item))
 
-    def on_number(self, attr, old, new):
+    def on_number(self, event):
         """Event-handler when a palette number is selected"""
-        self.notify(set_palette_number(int(new)))
+        self.notify(set_palette_number(int(event.item)))
 
     def on_reverse(self, attr, old, new):
         """Event-handler when reverse toggle is changed"""

--- a/forest/db/util.py
+++ b/forest/db/util.py
@@ -8,9 +8,9 @@ __all__ = [
 
 def autolabel(dropdown):
     """Automatically set Dropdown label on_click"""
-    def callback(attr, old, new):
+    def callback(event):
         for label, _value in dropdown.menu:
-            if new == _value:
+            if event.item == _value:
                 dropdown.label = label
-    dropdown.on_change("value", callback)
+    dropdown.on_click(callback)
     return callback

--- a/forest/drivers/intake_loader.py
+++ b/forest/drivers/intake_loader.py
@@ -110,7 +110,7 @@ INTAKE_TOOLTIPS = [
     ("Member", "@memberid"),
     ('Variable', "@variableid"), ]
 INTAKE_FORMATTERS = {
-    'valid': 'datetime',
+    '@valid': 'datetime',
 }
 
 

--- a/forest/main.py
+++ b/forest/main.py
@@ -136,11 +136,11 @@ def main(argv=None):
             width=50)
     autolabel(dropdown)
 
-    def on_change(attr, old, new):
+    def on_change(event):
         for feature in features:
             feature.glyph.line_color = new
 
-    dropdown.on_change("value", on_change)
+    dropdown.on_click(on_change)
 
     layers_ui = layers.LayersUI()
 

--- a/forest/main.py
+++ b/forest/main.py
@@ -458,5 +458,5 @@ def add_feature(figure, data, color="black"):
         color=color)
 
 
-if __name__.startswith("bk"):
+if __name__.startswith("bokeh"):
     main()

--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -1,90 +1,65 @@
-{% from macros import embed %}
 {% extends base %}
+
+<!-- Note: roots.attname raises ValueError if attname not found
+           see bokeh.embed.util.RenderRoots.__getitem__
+-->
+{% macro safe_embed(name) %}
+    {% for root in roots %}
+        {% if root.name == name %}
+           {{ embed(roots | attr(name)) }}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+
 {% block postamble %}
 <link rel="stylesheet" href="forest/static/style.css" type="text/css" media="all">
 <script src="forest/static/script.js" charset="utf-8"></script>
 {% endblock %}
+
 {% block contents %}
     <div id="sidenav" class="sidenav">
             <button type="button" onclick="closeId('sidenav')">Close</button>
-        {% for root in roots %}
-            {% if root.name == 'controls' %}
-                {{ embed(roots.controls) | indent(10) }}
-            {% endif %}
-        {% endfor %}
+            {{ safe_embed('controls') }}
     </div>
     <div id="diagrams" class="diagrams">
             <button type="button" onclick="closeId('diagrams')">Close</button>
-            {% for root in roots %}
-                {% if root.name == 'series' %}
-                    {{ embed(roots.series) | indent(10) }}
-                {% endif %}
-            {% endfor %}
+            {{ safe_embed('series') }}
     </div>
 
     <nav>
         <div class="display-inline-block float-left">
-        {% for root in roots %}
-            {% if root.name == 'sidenav_button' %}
-                {{ embed(roots.sidenav_button) | indent(10) }}
-            {% endif %}
-        {% endfor %}
+            {{ safe_embed('sidenav_button') }}
         </div>
         <div class="margin-left-110 display-inline-block float-left">
-        {% for root in roots %}
-            {% if root.name == 'headline' %}
-                {{ embed(roots.headline) | indent(10) }}
-            {% endif %}
-        {% endfor %}
+            {{ safe_embed('headline') }}
         </div>
         <!-- Embed optional button -->
-        {% for root in roots %}
-            <!-- Note: roots.attname raises ValueError if attname not found
-                       see bokeh.embed.util.RenderRoots.__getitem__
-            -->
-            {% if root.name == 'diagrams_button' %}
-                <div class="float-right">
-                {{ embed(roots.diagrams_button) | indent(10) }}
-                </div>
-            {% endif %}
-        {% endfor %}
+        <div class="float-right">
+            {{ safe_embed('diagrams_button') }}
+        </div>
     </nav>
 
     <!-- Add modal container -->
     <div id="modal" class="modal-outer">
-        {% for root in roots %}
-            {% if root.name == 'modal' %}
-                <div class="modal-inner">{{ embed(roots.modal) }}</div>
-            {% endif %}
-        {% endfor %}
+        <div class="modal-inner">
+            {{ safe_embed('modal') }}
+        </div>
     </div>
 
     <!-- Layout figure row -->
     <div id="figures">
-        {% for root in roots %}
-            {% if root.name == 'figures' %}
-                {{ embed(roots.figures) | indent(10) }}
-            {% endif %}
-        {% endfor %}
+        {{ safe_embed('figures') }}
     </div>
 
     <!-- Layout footer widgets -->
     <div id="colorbar-parent" class="colorbar-parent">
         <div id="colorbar" class="colorbar">
-            {% for root in roots %}
-                {% if root.name == 'colorbar' %}
-                    {{ embed(roots.colorbar) | indent(10) }}
-                {% endif %}
-            {% endfor %}
+            {{ safe_embed('colorbar') }}
         </div>
     </div>
     <footer>
         <div id="time" class="time">
-            {% for root in roots %}
-                {% if root.name == 'time' %}
-                    {{ embed(roots.time) | indent(10) }}
-                {% endif %}
-            {% endfor %}
+            {{ safe_embed('time') }}
         </div>
     </footer>
 
@@ -92,10 +67,11 @@
     {% for doc in docs %}
         {% for root in doc.roots %}
             <div class="display-none">
-            {{ embed(root) | indent(10) }}
+            {{ embed(root) }}
             </div>
         {% endfor %}
     {% endfor %}
+
     <script>
 // Re-attach roots if WebSocket request served by different machine
 let reattachRoots = function() {

--- a/forest/view.py
+++ b/forest/view.py
@@ -86,8 +86,8 @@ class UMView(AbstractMapView):
             ("Level", "@level")]
 
         self.formatters = {
-            'valid': 'datetime',
-            'initial': 'datetime'
+            '@valid': 'datetime',
+            '@initial': 'datetime'
         }
 
     @old_state

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh=1.4.0  # Port to 2.0.0 in future
+bokeh=2.0  # Port to 2.0.0 in future
 datashader
 h5netcdf
 iris

--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -123,13 +123,15 @@ def test_color_controls():
     color_mapper = bokeh.models.LinearColorMapper()
     controls = colors.ColorMapperView(color_mapper)
     controls.render({"name": "Accent", "number": 3})
-    assert color_mapper.palette == ['#7fc97f', '#beaed4', '#fdc086']
+    assert color_mapper.palette == ('#7fc97f', '#beaed4', '#fdc086')
 
 
 def test_controls_on_name(listener):
+    event = Mock()
+    event.item = 5
     controls = colors.ColorPalette()
     controls.add_subscriber(listener)
-    controls.on_number(None, None, 5)
+    controls.on_number(event)
     listener.assert_called_once_with(colors.set_palette_number(5))
 
 
@@ -182,9 +184,11 @@ def test_palette_numbers(name, expect):
 
 
 def test_controls_on_number(listener):
+    event = Mock()
+    event.item = 5
     controls = colors.ColorPalette()
     controls.add_subscriber(listener)
-    controls.on_number(None, None, 5)
+    controls.on_number(event)
     listener.assert_called_once_with(colors.set_palette_number(5))
 
 
@@ -221,9 +225,9 @@ def test_controls_render_sets_menu():
 
 @pytest.mark.parametrize("props,palette", [
         ({"name": "Accent", "number": 3},
-            ["#7fc97f", "#beaed4", "#fdc086"]),
+            ("#7fc97f", "#beaed4", "#fdc086")),
         ({"name": "Accent", "number": 3, "reverse": True},
-            ["#fdc086", "#beaed4", "#7fc97f"])
+            ("#fdc086", "#beaed4", "#7fc97f"))
     ])
 def test_controls_render_palette(props, palette):
     color_mapper = bokeh.models.LinearColorMapper()

--- a/test/test_db_util.py
+++ b/test/test_db_util.py
@@ -1,9 +1,13 @@
 import bokeh.models
 import forest.db.util
+from unittest.mock import Mock, sentinel
 
 
 def test_autolabel():
-    dropdown = bokeh.models.Dropdown(menu=[("label", "value")])
+    label, value = "Label", "value"
+    event = Mock()
+    event.item = value
+    dropdown = bokeh.models.Dropdown(menu=[(label, value)])
     callback = forest.db.util.autolabel(dropdown)
-    callback(None, None, "value")
-    assert dropdown.label == "label"
+    callback(event)
+    assert dropdown.label == label


### PR DESCRIPTION
# Migrate to Bokeh 2.0

To keep pace with latest Bokeh widgets patch implemented to address backwards incompatible upgrade from Bokeh 1.x to 2.x

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
