### PR TITLE
Component decorator

### DIFF
--- a/doc/source/howto-component.rst
+++ b/doc/source/howto-component.rst
@@ -25,7 +25,10 @@ pool of knowledge
 
 A user interface component typically has a two-way connection
 with the Store, it can both send actions to the store to
-be reduced and receive state updates to render itself.
+be reduced and receive state updates to render itself. While rendering
+it should not be possible to emit new actions. This behaviour is commonly
+referred to as one-way data flow. One-way data flow is enforced by the
+``forest.mark.component`` decorator.
 
 The intention is for all components to connect themselves
 to the store and be responsible for their own wiring. Most components
@@ -50,7 +53,11 @@ update?
 
 .. code:: python
 
+   from forest.mark import component
+
+   @component
    class ReactiveView:
+       """Re-render on state change"""
        ...
        def connect(self, store):
            # Views merely react to state changes
@@ -64,8 +71,18 @@ A simple user interface component should be able to
 send messages to the store as and when a user interacts
 with it.
 
+.. note:: It is good practice to use the ``@component`` decorator
+          to signal intention to  readers of the code
+          and to enforce one-way data flow where necessary
+
+Broadly speaking components connect to the store in either a one-way or
+two-way manner. One-way components send messages to the store and do
+not react to state changes. Two-way components both send messages and
+re-render on state change.
+
 .. code:: python
 
+    @component
     class OneWayUI(Observable):
         # Only sends actions to the store
         def __init__(self):
@@ -84,6 +101,7 @@ respond to state changes by updating its representation.
 
 .. code:: python
 
+    @component
     class TwoWayUI(Observable):
         # Same as OneWayUI but renders on state change
         ...
@@ -116,6 +134,7 @@ when those properties change.
 
     from forest import rx  # minimalist functional reactive programming
 
+    @component
     class EfficientUI(Observable):
         # Only renders when a property changes
 

--- a/forest/mark.py
+++ b/forest/mark.py
@@ -1,6 +1,7 @@
 """Decorators to mark classes and functions"""
 from unittest.mock import Mock
 from contextlib import contextmanager
+from functools import wraps
 from forest.observe import Observable
 
 
@@ -13,6 +14,7 @@ def component(cls):
 
 def disable_notify(render):
     """Disable self.notify during self.render"""
+    @wraps(render)
     def wrapper(self, *args, **kwargs):
         with disable(self, "notify"):
             return_value = render(self, *args, **kwargs)

--- a/forest/mark.py
+++ b/forest/mark.py
@@ -1,0 +1,29 @@
+"""Decorators to mark classes and functions"""
+from unittest.mock import Mock
+from contextlib import contextmanager
+from forest.observe import Observable
+
+
+def component(cls):
+    """Enforce one-way data-flow"""
+    if issubclass(cls, Observable) and hasattr(cls, "render"):
+        cls.render = disable_notify(cls.render)
+    return cls
+
+
+def disable_notify(render):
+    """Disable self.notify during self.render"""
+    def wrapper(self, *args, **kwargs):
+        with disable(self, "notify"):
+            return_value = render(self, *args, **kwargs)
+        return return_value
+    return wrapper
+
+
+@contextmanager
+def disable(obj, method_name):
+    """Temporarily disable a method inside a code block"""
+    method = getattr(obj, method_name)
+    setattr(obj, method_name, Mock())
+    yield
+    setattr(obj, method_name, method)

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock, sentinel
+from forest.observe import Observable
+import forest.mark
+
+
+@forest.mark.component
+class FakeComponent(Observable):
+    def on_change(self):
+        self.notify(None)
+
+    def render(self):
+        self.on_change()  # Should be disabled during self.render()
+
+
+@forest.mark.component
+class FakeOneWayComponent(Observable):
+    def on_change(self):
+        self.notify(None)
+
+
+def test_component_render():
+    """component.notify() forbidden during render"""
+    component = FakeComponent()
+    component.notify = Mock()
+    component.render()
+    assert not component.notify.called
+
+
+def test_component_on_change():
+    component = FakeComponent()
+    component.notify = Mock()
+    component.on_change()
+    assert component.notify.called
+
+
+def test_component_given_one_way_on_change():
+    component = FakeOneWayComponent()
+    component.notify = Mock()
+    component.on_change()
+    assert component.notify.called


### PR DESCRIPTION
# Component decorator

A pillar of react-redux design is to assume one-way data flow. E.g. a component that renders itself should not re-emit an action to change the state. Thus preventing complicated asynchronous feedback loops. This is important in the case where multiple views are controlling the same state property

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
