### PR TITLE
Feature flag plugin architecture

### DIFF
--- a/doc/source/howto-feature-toggles.rst
+++ b/doc/source/howto-feature-toggles.rst
@@ -7,6 +7,7 @@ ready for a wider audience. Feature toggles give developers and
 user experience wizards the ability to test features early in
 the cycle and give them insight into performance and usability.
 
+**Static feature flags**
 
 .. code-block:: yaml
 
@@ -18,8 +19,29 @@ To access these settings in main.py use the following syntax.
 
 .. code-block:: python
 
-   if config.features['foo']:
+   if forest.data.FEATURE_FLAGS['foo']:
        # Do foo feature
 
 
 As easy as that.
+
+**Dynamic feature flags**
+
+To add more sophisticated dynamic feature toggles it is possible to
+specify an ``entry_point`` that runs general purpose Python code to
+determine the feature flags dictionary.
+
+
+.. code-block:: yaml
+
+   plugins:
+     feature:
+       entry_point: lib.mod.func
+
+The string ``lib.mod.func`` is parsed into an import statement to
+import ``lib.mod`` and a call of the ``func`` method. This is very
+similar to how setup.py wires up commands.
+
+
+.. warning:: Since the entry_point could point to arbitrary Python code
+             make sure this feature is only used with trusted source code

--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.15.7'
+__version__ = '0.16.0'
 
 from .config import *
 from . import (

--- a/forest/config.py
+++ b/forest/config.py
@@ -23,7 +23,6 @@ applications.
 import os
 import string
 import yaml
-from enum import Enum
 from dataclasses import dataclass
 from collections import defaultdict
 from collections.abc import Mapping

--- a/forest/config.py
+++ b/forest/config.py
@@ -23,11 +23,42 @@ applications.
 import os
 import string
 import yaml
+from enum import Enum
+from dataclasses import dataclass
 from collections import defaultdict
+from collections.abc import Mapping
 from forest.export import export
 
 
 __all__ = []
+
+
+@dataclass
+class PluginSpec:
+    """Data representation of plugin"""
+    entry_point: str
+
+
+class Plugins(Mapping):
+    """Specialist mapping between allowed keys and specs"""
+    def __init__(self, data):
+        allowed = ("feature",)
+        self.data = {}
+        for key, value in data.items():
+            if key in allowed:
+                self.data[key] = PluginSpec(**value)
+            else:
+                msg = f"{key} not in {allowed}"
+                raise Exception(msg)
+
+    def __getitem__(self, *args, **kwargs):
+        return self.data.__getitem__(*args, **kwargs)
+
+    def __len__(self, *args, **kwargs):
+        return self.data.__len__(*args, **kwargs)
+
+    def __iter__(self, *args, **kwargs):
+        return self.data.__iter__(*args, **kwargs)
 
 
 class Viewport:
@@ -68,6 +99,7 @@ class Config(object):
     """
     def __init__(self, data):
         self.data = data
+        self.plugins = Plugins(self.data.get("plugins", {}))
 
     def __repr__(self):
         return "{}({})".format(

--- a/forest/main.py
+++ b/forest/main.py
@@ -16,6 +16,7 @@ from forest import (
         layers,
         db,
         keys,
+        plugin,
         presets,
         redux,
         rx,
@@ -45,7 +46,11 @@ def main(argv=None):
                     args.variables))
 
     # Feature toggles
-    data.FEATURE_FLAGS = config.features
+    if "feature" in config.plugins:
+        features = plugin.call(config.plugins["feature"].entry_point)
+    else:
+        features = config.features
+    data.FEATURE_FLAGS = features
 
     # Full screen map
     viewport = config.default_viewport

--- a/forest/plugin.py
+++ b/forest/plugin.py
@@ -1,0 +1,9 @@
+"""Simple plugin architecture"""
+import importlib
+
+
+def call(entry_point):
+    """Call entry_point to run plugin"""
+    *parts, method = entry_point.split(".")
+    module = importlib.import_module(".".join(parts))
+    return getattr(module, method)()

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -217,3 +217,25 @@ def test_config_parser_use_web_map_tiles(data, expect):
 def test_config_parser_features(data, expect):
     config = forest.config.Config(data)
     assert config.features["example"] == expect
+
+
+def test_config_parser_plugin_entry_points():
+    config = forest.config.Config({
+        "plugins": {
+            "feature": {
+                "entry_point": "module.main"
+            }
+        }
+    })
+    assert config.plugins["feature"].entry_point == "module.main"
+
+
+def test_config_parser_plugin_given_unsupported_key():
+    with pytest.raises(Exception):
+         forest.config.Config({
+            "plugins": {
+                "not_a_key": {
+                    "entry_point": "module.main"
+                }
+            }
+        })


### PR DESCRIPTION
# Support DynamoDB or any third-party Python SDK plugin for feature flags

Provides `entry_point` as an alternative to hard coding feature flags in the config file

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
