### PR TITLE
Use data.FEATURE_FLAGS to access web based feature flags

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.16.0'
+__version__ = '0.16.1'
 
 from .config import *
 from . import (

--- a/forest/main.py
+++ b/forest/main.py
@@ -216,7 +216,7 @@ def main(argv=None):
             "profile": "Display Profile"
         }
     available_features = {k: display_names[k]
-                          for k in display_names.keys() if config.features[k]}
+                          for k in display_names.keys() if data.FEATURE_FLAGS[k]}
 
     tools_panel = tools.ToolsPanel(available_features)
     tools_panel.connect(store)
@@ -256,7 +256,7 @@ def main(argv=None):
     controls.connect(store)
 
     # Add support for a modal dialogue
-    if config.features["multiple_colorbars"]:
+    if data.FEATURE_FLAGS["multiple_colorbars"]:
         view = forest.components.modal.Tabbed()
     else:
         view = forest.components.modal.Default()
@@ -327,7 +327,7 @@ def main(argv=None):
         ])
 
     tool_figures = {}
-    if config.features["time_series"]:
+    if data.FEATURE_FLAGS["time_series"]:
         # Series sub-figure widget
         series_figure = bokeh.plotting.figure(
                     plot_width=400,
@@ -351,7 +351,7 @@ def main(argv=None):
 
         tool_figures["series_figure"] = series_figure
 
-    if config.features["profile"]:
+    if data.FEATURE_FLAGS["profile"]:
         # Profile sub-figure widget
         profile_figure = bokeh.plotting.figure(
                     plot_width=300,


### PR DESCRIPTION
# Use dynamic feature flags not config file flags

- Replace `config.features` with `data.FEATURE_FLAGS` to access dynamic flags

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
