### PR TITLE
use os.path.join and not / to support Windows build

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.16.2'
+__version__ = '0.16.3'
 
 from .config import *
 from . import (

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class BuildJSCommand(setuptools.command.build_py.build_py):
     """
     def run(self):
         cwd = os.getcwd()
-        os.chdir("forest/js")
+        os.chdir(os.path.join("forest", "js"))
         if not os.path.exists("node_modules"):
             subprocess.check_call(["npm", "install"])
         subprocess.check_call(["npm", "run", "build"])


### PR DESCRIPTION
# Support windows nodejs build

- Use `os.path.join` instead of explicit path separator

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
