### PR TITLE
use absolute path to find JS on Windows

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.16.3'
+__version__ = '0.16.4'
 
 from .config import *
 from . import (

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import setuptools.command.install
 
 
 NAME = "forest"
+JS_DIR = os.path.join(os.path.dirname(__file__), NAME, r"js")
 
 
 def find_version():
@@ -63,7 +64,7 @@ class BuildJSCommand(setuptools.command.build_py.build_py):
     """
     def run(self):
         cwd = os.getcwd()
-        os.chdir(os.path.join("forest", "js"))
+        os.chdir(JS_DIR)
         if not os.path.exists("node_modules"):
             subprocess.check_call(["npm", "install"])
         subprocess.check_call(["npm", "run", "build"])


### PR DESCRIPTION
# Absolute path

Attempt to solve `[WinError 2]` experienced on conda-forge for Windows builds

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
