### PR TITLE
Fix server container

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.17.0'
+__version__ = '0.17.1'
 
 from .config import *
 from . import (

--- a/forest/static/forest-min.js
+++ b/forest/static/forest-min.js
@@ -1,0 +1,26 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+const helloWorld = () => "Hello, World!"
+
+
+// Populate variable options from dataset value
+const link_selects = function(dataset_select, variable_select, source) {
+    let label = dataset_select.value;
+    if (label !== "") {
+        let index = source.data['datasets'].indexOf(label)
+        let defaults = ["Please specify"];
+        variable_select.options = defaults.concat(
+            source.data['variables'][index]);
+    }
+}
+
+
+module.exports = {
+    helloWorld,
+    link_selects
+}
+
+},{}],2:[function(require,module,exports){
+window.forest = require('./forest')
+
+
+},{"./forest":1}]},{},[2]);


### PR DESCRIPTION
# Add pre-built JS

- Docker container on AWS does not use `python setup.py` or `conda install forest` to deploy. This is a temporary solution until a more permanent fix can be made

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
