### PR TITLE
Fix timestamp old state

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -23,7 +23,7 @@ forecasts alongside observations.
 .. automodule:: forest.presets
 
 """
-__version__ = '0.17.1'
+__version__ = '0.17.2'
 
 from .config import *
 from . import (

--- a/forest/db/control.py
+++ b/forest/db/control.py
@@ -118,11 +118,16 @@ def time_array_equal(x, y):
         return False
     elif (len(x) == 0) or (len(y) == 0):
         return x == y
-    try:
-        return np.all(_vto_datetime(x) == _vto_datetime(y))
-    except TypeError:
-        # NOTE: Needed for EarthNetworks DatetimeIndex
-        return np.all(pd.to_datetime(x) == pd.to_datetime(y))
+    else:
+        if len(x) != len(y):
+            return False
+        try:
+            left, right = _vto_datetime(x), _vto_datetime(y)
+        except TypeError:
+            # NOTE: Needed for EarthNetworks DatetimeIndex
+            left, right = pd.to_datetime(x), pd.to_datetime(y)
+        return np.all(left == right)
+
 
 def equal_value(a, b):
     if (a is None) and (b is None):

--- a/forest/db/control.py
+++ b/forest/db/control.py
@@ -121,13 +121,17 @@ def time_array_equal(x, y):
     else:
         if len(x) != len(y):
             return False
-        try:
-            left, right = _vto_datetime(x), _vto_datetime(y)
-        except TypeError:
-            # NOTE: Needed for EarthNetworks DatetimeIndex
-            left, right = pd.to_datetime(x), pd.to_datetime(y)
+        left = _as_datetime_array(x)
+        right = _as_datetime_array(x)
         return np.all(left == right)
 
+def _as_datetime_array(x):
+    """Either vectorized _to_datetime or pd.to_datetime"""
+    try:
+        return _vto_datetime(x)
+    except TypeError:
+        # NOTE: Needed for EarthNetworks DatetimeIndex
+        return pd.to_datetime(x)
 
 def equal_value(a, b):
     if (a is None) and (b is None):

--- a/forest/db/control.py
+++ b/forest/db/control.py
@@ -122,7 +122,7 @@ def time_array_equal(x, y):
         if len(x) != len(y):
             return False
         left = _as_datetime_array(x)
-        right = _as_datetime_array(x)
+        right = _as_datetime_array(y)
         return np.all(left == right)
 
 def _as_datetime_array(x):

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -2,6 +2,7 @@ import pytest
 import datetime as dt
 import numpy as np
 import pandas as pd
+import cftime
 from forest import db
 from forest.db.control import time_array_equal
 
@@ -66,3 +67,11 @@ def test_valueerror_lengths_must_match():
     b = ["2020-02-01T00:00:00Z", "2020-02-02T00:00:00Z", "2020-02-03T00:00:00Z"]
     with pytest.raises(ValueError):
         pd.to_datetime(a) == pd.to_datetime(b)
+
+
+def test_time_array_equal_mixed_types():
+    left = [cftime.DatetimeGregorian(2020, 1, 1),
+            cftime.DatetimeGregorian(2020, 1, 2),
+            cftime.DatetimeGregorian(2020, 1, 3)]
+    right = pd.date_range("2020-01-01", periods=3)
+    assert time_array_equal(left, right) == True

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -69,9 +69,19 @@ def test_valueerror_lengths_must_match():
         pd.to_datetime(a) == pd.to_datetime(b)
 
 
-def test_time_array_equal_mixed_types():
-    left = [cftime.DatetimeGregorian(2020, 1, 1),
-            cftime.DatetimeGregorian(2020, 1, 2),
-            cftime.DatetimeGregorian(2020, 1, 3)]
-    right = pd.date_range("2020-01-01", periods=3)
-    assert time_array_equal(left, right) == True
+@pytest.mark.parametrize("left,right,expect", [
+    pytest.param([cftime.DatetimeGregorian(2020, 1, 1),
+                  cftime.DatetimeGregorian(2020, 1, 2),
+                  cftime.DatetimeGregorian(2020, 1, 3)],
+                 pd.date_range("2020-01-01", periods=3),
+                 True,
+                 id="gregorian/pandas same values"),
+    pytest.param([cftime.DatetimeGregorian(2020, 2, 1),
+                  cftime.DatetimeGregorian(2020, 2, 2),
+                  cftime.DatetimeGregorian(2020, 2, 3)],
+                 pd.date_range("2020-01-01", periods=3),
+                 False,
+                 id="gregorian/pandas same length different values"),
+])
+def test_time_array_equal_mixed_types(left, right, expect):
+    assert time_array_equal(left, right) == expect

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -1,7 +1,9 @@
 import pytest
 import datetime as dt
 import numpy as np
+import pandas as pd
 from forest import db
+from forest.db.control import time_array_equal
 
 
 @pytest.mark.parametrize("left,right,expect", [
@@ -35,8 +37,32 @@ from forest import db
         (db.State(), db.State(variables=["a", "b"]), False),
         (db.State(variables=["a", "b"]), db.State(variables=["a", "b"]), True),
         (db.State(variables=np.array(["a", "b"])),
-            db.State(variables=["a", "b"]), True),
+            db.State(variables=["a", "b"]), True)
         ])
 def test_equality_and_not_equality(left, right, expect):
     assert (left == right) == expect
     assert (left != right) == (not expect)
+
+
+def test_state_equality_valueerror_lengths_must_match():
+    """should return False if lengths do not match"""
+    valid_times = (
+        pd.date_range("2020-01-01", periods=2),
+        pd.date_range("2020-01-01", periods=3),
+    )
+    left = db.State(valid_times=valid_times[0])
+    right = db.State(valid_times=valid_times[1])
+    assert (left == right) == False
+
+
+def test_time_array_equal():
+    left = pd.date_range("2020-01-01", periods=2)
+    right = pd.date_range("2020-01-01", periods=3)
+    assert time_array_equal(left, right) == False
+
+
+def test_valueerror_lengths_must_match():
+    a = ["2020-01-01T00:00:00Z"]
+    b = ["2020-02-01T00:00:00Z", "2020-02-02T00:00:00Z", "2020-02-03T00:00:00Z"]
+    with pytest.raises(ValueError):
+        pd.to_datetime(a) == pd.to_datetime(b)


### PR DESCRIPTION
# Pandas Timestamp raises ValueError if lengths not equal

- Add tests to ensure `False` returned instead of `ValueError`
- Add support for comparing `cftime.DatetimeGregorian` to `pandas.Timestamp` or indeed any datetime-like type that can pass through `forest.util.to_datetime` or `pandas.to_datetime`

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
