### PR TITLE
Database.valid_times remove kwargs

### DIFF
--- a/forest/db/control.py
+++ b/forest/db/control.py
@@ -181,10 +181,7 @@ def initial_state(navigator, pattern=None):
         return state
     initial_time = max(initial_times)
     state["initial_time"] = initial_time
-    valid_times = navigator.valid_times(
-        variable=variable,
-        pattern=pattern,
-        initial_time=initial_time)
+    valid_times = navigator.valid_times(pattern, variable, initial_time)
     state["valid_times"] = valid_times
     if len(valid_times) > 0:
         state["valid_time"] = min(valid_times)
@@ -359,13 +356,12 @@ class Controls(object):
         yield set_value("initial_times", initial_times)
 
         # Set valid_times if pattern, variable and initial_time present
-        kwargs = {
-            "pattern": pattern,
-            "variable": store.state.get("variable"),
-            "initial_time": store.state.get("initial_time"),
-        }
-        if all(kwargs[k] is not None for k in ["variable", "initial_time"]):
-            valid_times = self.navigator.valid_times(**kwargs)
+        variable = store.state.get("variable")
+        initial_time = store.state.get("initial_time")
+        if all(value is not None for value in [variable, initial_time]):
+            valid_times = self.navigator.valid_times(pattern,
+                                                     variable,
+                                                     initial_time)
             yield set_value("valid_times", valid_times)
 
     def _variable(self, store, action):

--- a/forest/db/database.py
+++ b/forest/db/database.py
@@ -371,10 +371,7 @@ class Database(Connection):
                 (SELECT id FROM pressure WHERE value=:pressure AND i=:i))
         """, dict(path=path, variable=variable, pressure=pressure, i=i))
 
-    def valid_times(self,
-                    pattern=None,
-                    variable=None,
-                    initial_time=None):
+    def valid_times(self, pattern, variable, initial_time):
         """Valid times associated with search criteria"""
         # Note: SQL injection possible if not properly escaped
         #       use ? and :name syntax in template

--- a/test/test_db_current.py
+++ b/test/test_db_current.py
@@ -120,7 +120,8 @@ class TestDatabase(unittest.TestCase):
                 ("file_1.nc", "var_b", "2019-01-01 02:00:00", 0),
                 ("file_2.nc", "var_b", "2019-01-01 03:00:00", 0)]:
             self.database.insert_time(path, variable, time, i)
-        result = self.database.valid_times()
+        pattern, variable, initial_time = None, None, None
+        result = self.database.valid_times(pattern, variable, initial_time)
         expect = [
             "2019-01-01 00:00:00",
             "2019-01-01 01:00:00",
@@ -135,7 +136,8 @@ class TestDatabase(unittest.TestCase):
                 ("file_1.nc", "var_b", "2019-01-01 02:00:00", 0),
                 ("file_2.nc", "var_b", "2019-01-01 03:00:00", 0)]:
             self.database.insert_time(path, variable, time, i)
-        result = self.database.valid_times(variable="var_b")
+        pattern, variable, initial_time = None, "var_b", None
+        result = self.database.valid_times(pattern, variable, initial_time)
         expect = ["2019-01-01 02:00:00", "2019-01-01 03:00:00"]
         self.assertEqual(expect, result)
 
@@ -146,7 +148,8 @@ class TestDatabase(unittest.TestCase):
                 ("file_1.nc", "2019-01-01 02:00:00", 0),
                 ("file_2.nc", "2019-01-01 03:00:00", 0)]:
             self.database.insert_time(path, self.variable, time, i)
-        result = self.database.valid_times(pattern="*_1.nc")
+        pattern, variable, initial_time = "*_1.nc", None, None
+        result = self.database.valid_times(pattern, variable, initial_time)
         expect = ["2019-01-01 01:00:00", "2019-01-01 02:00:00"]
         self.assertEqual(expect, result)
 
@@ -157,9 +160,8 @@ class TestDatabase(unittest.TestCase):
                 ("file_1.nc", "var_b", "2019-01-01 02:00:00", 0),
                 ("file_2.nc", "var_b", "2019-01-01 03:00:00", 0)]:
             self.database.insert_time(path, variable, time, i)
-        result = self.database.valid_times(
-            pattern="*_1.nc",
-            variable="var_b")
+        pattern, variable, initial_time = "*_1.nc", "var_b", None
+        result = self.database.valid_times(pattern, variable, initial_time)
         expect = ["2019-01-01 02:00:00"]
         self.assertEqual(expect, result)
 
@@ -177,7 +179,8 @@ class TestDatabase(unittest.TestCase):
             self.database.insert_file_name(path, initial)
             for i, time in enumerate(times):
                 self.database.insert_time(path, self.variable, time, i)
-        result = self.database.valid_times(initial_time="2019-01-01 00:00:00")
+        pattern, variable, initial_time = None, None, "2019-01-01 00:00:00"
+        result = self.database.valid_times(pattern, variable, initial_time)
         expect = [
             "2019-01-01 03:00:00",
             "2019-01-01 06:00:00"]
@@ -200,9 +203,8 @@ class TestDatabase(unittest.TestCase):
             self.database.insert_file_name(path, initial)
             for i, (variable, time) in enumerate(items):
                 self.database.insert_time(path, variable, time, i)
-        result = self.database.valid_times(
-            variable="y",
-            initial_time="2019-01-01 00:00:00")
+        pattern, variable, initial_time = None, "y", "2019-01-01 00:00:00"
+        result = self.database.valid_times(pattern, variable, initial_time)
         expect = [
             "2019-01-01 06:00:00",
             "2019-01-01 09:00:00"]

--- a/test/test_db_database.py
+++ b/test/test_db_database.py
@@ -27,7 +27,7 @@ def _assert_query_and_params(db, expected_query, expected_params):
 def test_Database_valid_times__defaults():
     db = _create_db()
 
-    valid_times = db.valid_times()
+    valid_times = db.valid_times(None, None, None)
 
     _assert_query_and_params(db, 'SELECT time.value FROM time',
                              {'pattern': None, 'variable': None,


### PR DESCRIPTION
# Remove keyword args from `Database.valid_times`

- Ease future PR to support `datetime`-like args to `Database` by simplifying call signature

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
