### PR TITLE
Bokeh2 windbarb

### DIFF
--- a/forest/wind/barb.py
+++ b/forest/wind/barb.py
@@ -1,8 +1,6 @@
 import bokeh.plotting
-from bokeh.plotting.helpers import _glyph_function
 import bokeh.models
 from bokeh.core.properties import DistanceSpec
-
 
 class Barb(bokeh.models.XYGlyph):
     __implementation__ = "barb.ts"
@@ -12,7 +10,11 @@ class Barb(bokeh.models.XYGlyph):
     u = DistanceSpec(units_default="screen")
     v = DistanceSpec(units_default="screen")
 
+def barb():
+    '''Dummy function to be replaced with decorated function'''
+    return True
+
 
 # Extend bokeh.plotting.Figure to support .barb()
 if not hasattr(bokeh.plotting.Figure, 'barb'):
-    bokeh.plotting.Figure.barb = _glyph_function(Barb)
+    bokeh.plotting.Figure.barb = bokeh.plotting._decorators.glyph_method(Barb)(barb)

--- a/forest/wind/barb.py
+++ b/forest/wind/barb.py
@@ -1,14 +1,14 @@
 import bokeh.plotting
 import bokeh.models
-from bokeh.core.properties import DistanceSpec
+from bokeh.core.properties import DistanceSpec, NumberSpec
 
 class Barb(bokeh.models.XYGlyph):
     __implementation__ = "barb.ts"
     _args = ('x', 'y', 'u', 'v')
     x = DistanceSpec(units_default="screen")
     y = DistanceSpec(units_default="screen")
-    u = DistanceSpec(units_default="screen")
-    v = DistanceSpec(units_default="screen")
+    u = NumberSpec()
+    v = NumberSpec()
 
 def barb():
     '''Dummy function to be replaced with decorated function'''

--- a/forest/wind/barb.ts
+++ b/forest/wind/barb.ts
@@ -74,8 +74,8 @@ export namespace Barb {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = XYGlyph.Props & LineVector & FillVector & {
-    u: p.DistanceSpec
-    v: p.DistanceSpec
+    u: p.NumberSpec
+    v: p.NumberSpec
     barb_dimension: p.Property<RadiusDimension>
   }
 
@@ -96,8 +96,8 @@ export class Barb extends XYGlyph {
 
     this.mixins(['line', 'fill'])
     this.define<Barb.Props>({
-      u: [ p.DistanceSpec,    { units: "screen", value: 0 } ],
-      v: [ p.DistanceSpec,    { units: "screen", value: 0 } ],
+      u: [ p.NumberSpec,    { value: 0 } ],
+      v: [ p.NumberSpec,    { value: 0 } ],
       barb_dimension: [ p.RadiusDimension, 'x' ],
     })
   }


### PR DESCRIPTION
### Bokeh2.0 Windbarb code

Updates the wind barb code to a) work with Bokeh2 and b) accept negative _u_ and _v_ values ( by changing `DistanceSpec` to `NumberSpec`)

## Check list

I have not checked the existing app works as expected because I'm not sure how you run it, but I think it should work.

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
